### PR TITLE
Improvements to social sharing on Twitter

### DIFF
--- a/admin_fn.php
+++ b/admin_fn.php
@@ -61,6 +61,7 @@ wp_enqueue_media();
         mdx_update_option("mdx_enhanced_ajax", sanitize_text_field($_POST['mdx_enhanced_ajax']));
         mdx_update_option('mdx_speed_pre', sanitize_text_field($_POST['mdx_speed_pre']));
         mdx_update_option('mdx_share_area', sanitize_text_field($_POST['mdx_share_area']));
+        mdx_update_option('mdx_share_twitter_card', sanitize_text_field($_POST['mdx_share_twitter_card'])??"summary");
         mdx_update_option('mdx_hot_posts', sanitize_text_field($_POST['mdx_hot_posts']));
         mdx_update_option('mdx_hot_posts_get', sanitize_text_field($_POST['mdx_hot_posts_get']));
         mdx_update_option('mdx_hot_posts_num', sanitize_text_field($_POST['mdx_hot_posts_num']));
@@ -255,6 +256,20 @@ wp_enqueue_media();
                             <option value="oversea" <?php if ($mdx_v_share_area == 'oversea'){ ?>selected="selected"<?php } ?>><?php _e('只有国际服务商', 'mdx'); ?></option>
                         </select>
                         <p class="description"><?php _e('指定你想提供给访问者的分享服务商。</p><ul><li><code>只有中国国内服务商</code>：提供 微博、微信、QQ、QQ 空间 的分享</li><li><code>只有国际服务商</code>：提供 Telegrame、Twitter、Facebook 的分享</li></ul><p>无论如何，“生成分享图”始终启用。', 'mdx'); ?></p>
+                    </td>
+                </tr>
+                <tr>
+                    <th scope="row"><label for="mdx_share_twitter_card"><?php _e('Twitter Card 分享类型', 'mdx'); ?></label></th>
+                    <td>
+                        <?php $mdx_v_share_twitter_card = mdx_get_option('mdx_share_twitter_card'); ?>
+                        <fieldset>
+                            <label>
+                                <input type="radio" name="mdx_share_twitter_card" value="summary" <?php if ($mdx_v_share_twitter_card == 'summary'){ ?>checked="checked"<?php } ?>> <?php _e("描述卡片","mdx"); ?>
+                            </label><br>
+                            <label>
+                                <input type="radio" name="mdx_share_twitter_card" value="summary_large_image" <?php if ($mdx_v_share_twitter_card == 'summary_large_image'){ ?>checked="checked"<?php } ?>> <?php _e("大型带图卡片","mdx"); ?>
+                            </label><br>
+                        </fieldset>
                     </td>
                 </tr>
             </tbody>

--- a/admin_fn.php
+++ b/admin_fn.php
@@ -62,6 +62,7 @@ wp_enqueue_media();
         mdx_update_option('mdx_speed_pre', sanitize_text_field($_POST['mdx_speed_pre']));
         mdx_update_option('mdx_share_area', sanitize_text_field($_POST['mdx_share_area']));
         mdx_update_option('mdx_share_twitter_card', sanitize_text_field($_POST['mdx_share_twitter_card'])??"summary");
+        mdx_update_option('mdx_share_twitter_username', sanitize_text_field($_POST['mdx_share_twitter_username']));
         mdx_update_option('mdx_hot_posts', sanitize_text_field($_POST['mdx_hot_posts']));
         mdx_update_option('mdx_hot_posts_get', sanitize_text_field($_POST['mdx_hot_posts_get']));
         mdx_update_option('mdx_hot_posts_num', sanitize_text_field($_POST['mdx_hot_posts_num']));
@@ -256,6 +257,13 @@ wp_enqueue_media();
                             <option value="oversea" <?php if ($mdx_v_share_area == 'oversea'){ ?>selected="selected"<?php } ?>><?php _e('只有国际服务商', 'mdx'); ?></option>
                         </select>
                         <p class="description"><?php _e('指定你想提供给访问者的分享服务商。</p><ul><li><code>只有中国国内服务商</code>：提供 微博、微信、QQ、QQ 空间 的分享</li><li><code>只有国际服务商</code>：提供 Telegrame、Twitter、Facebook 的分享</li></ul><p>无论如何，“生成分享图”始终启用。', 'mdx'); ?></p>
+                    </td>
+                </tr>
+                <tr>
+                    <th scope="row"><label for="mdx_share_twitter_username"><?php _e('Twitter 用户名', 'mdx'); ?></label></th>
+                    <td>
+                        <input name="mdx_share_twitter_username" type="text" id="mdx_share_twitter_username" value="<?php echo esc_attr(mdx_get_option('mdx_share_twitter_username')) ?>" class="regular-text">
+                        <p class="description"><?php _e('直接输入Twitter用户名，不要加入‘@’等，网站链接分享至Twitter时会显示站点所有者。<br/>具体请前往<a href="https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/summary-card-with-large-image#reference" target="_blank">https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/summary-card-with-large-image</a>', 'mdx'); ?></p>
                     </td>
                 </tr>
                 <tr>

--- a/header.php
+++ b/header.php
@@ -1,46 +1,63 @@
-﻿<!DOCTYPE html>
+﻿<?php
+//引用全局变量
+global $wp;
+global $files_root;
+global $page, $paged;
+
+// 获取当前页面Title
+$title = "";
+$title .= wp_title('-', true, 'right');
+$title .= get_bloginfo('name');
+$site_description = get_bloginfo('description', 'display');
+if ($site_description && (is_home() || is_front_page())) $title .= " - $site_description";
+if ($paged >= 2 || $page >= 2) $title .= ' - ' . sprintf(__('第 %s 页'), max($paged, $page));
+
+// 获取当前页面分享图
+$opt_mdx_index_img = mdx_get_option('mdx_index_img');
+$coverPicIsBing = (bool)substr($opt_mdx_index_img, 0, 6) == "--Bing";
+$index_image = !(!is_single() && !is_page() && $coverPicIsBing)?((is_single() || is_page())?(wp_get_attachment_image_src(get_post_thumbnail_id($post->ID), 'full')[0]??""):$opt_mdx_index_img):mdx_get_option('mdx_side_head');
+
+// 获取当前页面社会分享描述
+$social_describe = "";
+$mdx_des = mdx_get_option('mdx_seo_des');
+if (is_single() || is_page()) {
+    if (post_password_required()) {
+        $social_describe = translate('这篇文章受密码保护，输入密码后才能查看。', 'mdx');
+    } else {
+        $social_describe = mdx_get_post_excerpt($post, 100);
+    }
+} else if ($mdx_des != '') {
+    $social_describe = $mdx_des;
+} else {
+    $social_describe = get_bloginfo('description', 'display');
+}
+
+// PS: 判断页面类型的我还能再优化，但实在太懒（划掉）
+?>
+<!DOCTYPE html>
 <html <?php language_attributes(); ?>>
 <head>
     <meta charset="<?php bloginfo('charset'); ?>">
-    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=<?php if (mdx_get_option('mdx_allow_scale') == 'false') {
-        echo '1, user-scalable=no';
-    } else {
-        echo '5';
-    } ?>">
-    <?php if (mdx_get_option('mdx_speed_pre') == 'true' && !is_404()) { ?>
-        <?php if (is_home()) {
-            $mdx_js_name2 = 'js';
-        } else if (is_category() || is_archive() || is_search()) {
-            $mdx_js_name2 = 'ac';
-        } else if (is_single()) {
-            $mdx_js_name2 = 'post';
-        } else if (is_page()) {
-            $mdx_js_name2 = 'page';
-        } else {
-            $mdx_js_name2 = 'js';
-        }
-        global $files_root;
-        ?>
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=<?php echo (mdx_get_option('mdx_allow_scale') == 'false')?"1, user-scalable=no":"5"; ?>">
+    <?php if (mdx_get_option('mdx_speed_pre') == 'true' && !is_404()) {
+        if (is_home()) { $mdx_js_name2 = 'js'; } else if (is_category() || is_archive() || is_search()) { $mdx_js_name2 = 'ac'; } else if (is_single()) { $mdx_js_name2 = 'post'; } else if (is_page()) { $mdx_js_name2 = 'page'; } else { $mdx_js_name2 = 'js'; } ?>
+
         <link rel="preload" href="<?php echo $files_root; ?>/js/common.js?ver=<?php echo get_option("mdx_version_commit"); ?>" as="script">
         <link rel="preload" href="<?php echo $files_root; ?>/js/<?php echo $mdx_js_name2 ?>.js?ver=<?php echo get_option("mdx_version_commit"); ?>" as="script">
-        <link rel="preload" href="<?php echo $files_root; ?>/mdui/icons/material-icons/<?php if (mdx_get_option("mdx_md2") == "false") { ?>MaterialIcons-Regular.woff2<?php } else { ?>material_2_icon_font.woff2<?php } ?>" as="font" type="font/woff2" crossorigin>
+        <link rel="preload" href="<?php echo $files_root; ?>/mdui/icons/material-icons/<?php echo (mdx_get_option("mdx_md2") == "false")?"MaterialIcons-Regular.woff2":"material_2_icon_font.woff2" ?>" as="font" type="font/woff2" crossorigin>
         <?php if (mdx_get_option('mdx_md2') == "true" && mdx_get_option('mdx_md2_font') == "true") { ?>
             <link rel="preload" href="<?php echo $files_root; ?>/fonts/Montserrat-Regular.woff2" as="font" type="font/woff2" crossorigin>
             <link rel="preload" href="<?php echo $files_root; ?>/fonts/Montserrat-SemiBold.woff2" as="font" type="font/woff2" crossorigin>
-        <?php }
-    } ?>
+        <?php } ?>
+    <?php } ?>
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <!-- Theme developed by AxtonYao -->
+    <meta name="author" content="AxtonYao" />
     <?php if (mdx_get_option('mdx_safari') == "true") { ?>
         <link rel="mask-icon" href="<?php echo mdx_get_option('mdx_svg'); ?>" color="<?php echo mdx_get_option('mdx_svg_color'); ?>">
     <?php } ?>
     <?php if (mdx_get_option("mdx_title_med") == "diy") { ?>
-        <title itemprop="name"><?php global $page, $paged;
-            wp_title('-', true, 'right');
-            bloginfo('name');
-            $site_description = get_bloginfo('description', 'display');
-            if ($site_description && (is_home() || is_front_page())) echo " - $site_description";
-            if ($paged >= 2 || $page >= 2) echo ' - ' . sprintf(__('第 %s 页'), max($paged, $page)); ?>
-        </title>
+        <title itemprop="name"><?php echo $title; ?></title>
     <?php } ?>
     <?php if (is_single() || is_page()) {
         if (function_exists('get_query_var')) {
@@ -52,85 +69,25 @@
         }
     } ?>
     <?php if (!is_404()) { ?>
-        <meta property="og:title" content="<?php global $page, $paged;
-        wp_title('-', true, 'right');
-        bloginfo('name');
-        $site_description = get_bloginfo('description', 'display');
-        if ($site_description && (is_home() || is_front_page())) echo " - $site_description";
-        if ($paged >= 2 || $page >= 2) echo ' - ' . sprintf(__('第 %s 页'), max($paged, $page)); ?>">
+        <meta property="og:title" content="<?php echo $title; ?>">
         <meta property="og:type" content="article">
-        <meta property="og:url" content="<?php global $wp;
+        <meta property="og:url" content="<?php
         $mdx_current_url = mdx_get_now_url(is_single(), isset($post) ? (int)$post->ID : 0);
         echo $mdx_current_url; ?>">
         <?php
         $mdx_des = mdx_get_option('mdx_seo_des');
         $mdx_s_key = mdx_get_option('mdx_seo_key');
         $mdx_a_des = mdx_get_option('mdx_auto_des'); ?>
-        <meta property="og:description" content="<?php if (is_single() || is_page()) {
-            if (post_password_required()) {
-                _e('这篇文章受密码保护，输入密码后才能查看。', 'mdx');
-            } else {
-                echo mdx_get_post_excerpt($post, 100);
-            }
-        } else if ($mdx_des != '') {
-            echo $mdx_des;
-        } else {
-            bloginfo('description', 'display');
-        } ?>">
-        <?php $mdx_index_img = mdx_get_option('mdx_index_img');
-        if (!((!(is_single() || is_page())) && substr($mdx_index_img, 0, 6) == "--Bing")) { ?>
-            <meta property="og:image" content="<?php if (is_single() || is_page()) {
-                $mdx_post_img = wp_get_attachment_image_src(get_post_thumbnail_id($post->ID), 'full');
-                if (isset($mdx_post_img[0])) {
-                    echo $mdx_post_img[0];
-                } else {
-                    echo "";
-                }
-            } else {
-                echo $mdx_index_img;
-            } ?>">
-        <?php } ?>
+        <meta property="og:description" content="<?php echo $social_describe; ?>">
+        <meta property="og:image" content="<?php echo $index_image; ?>">
         <meta name="twitter:card" content="summary">
-        <meta name="twitter:title" content="<?php wp_title('-', true, 'right');
-        bloginfo('name');
-        if ($site_description && (is_home() || is_front_page())) echo " - $site_description";
-        if ($paged >= 2 || $page >= 2) echo ' - ' . sprintf(__('第 %s 页'), max($paged, $page)); ?>">
-        <meta name="twitter:description" content="<?php if (is_single() || is_page()) {
-            if (post_password_required()) {
-                _e('这篇文章受密码保护，输入密码后才能查看。', 'mdx');
-            } else {
-                echo mdx_get_post_excerpt($post, 100);
-            }
-        } else if ($mdx_des != '') {
-            echo $mdx_des;
-        } else {
-            bloginfo('description', 'display');
-        } ?>">
+        <meta name="twitter:title" content="<?php echo $title; ?>">
+        <meta name="twitter:description" content="<?php echo $social_describe; ?>">
         <meta name="twitter:url" content="<?php echo $mdx_current_url; ?>">
-        <?php if (!((!(is_single() || is_page())) && substr($mdx_index_img, 0, 6) == "--Bing")) { ?>
-            <meta name="twitter:image" content="<?php if (is_single() || is_page()) {
-                if ($mdx_post_img !== false && $mdx_post_img[0] != "") {
-                    echo $mdx_post_img[0];
-                } else {
-                    echo "";
-                }
-            } else {
-                echo $mdx_index_img;
-            } ?>">
-            <meta itemprop="name" content="<?php wp_title('-', true, 'right');
-            bloginfo('name');
-            if ($site_description && (is_home() || is_front_page())) echo " - $site_description";
-            if ($paged >= 2 || $page >= 2) echo ' - ' . sprintf(__('第 %s 页'), max($paged, $page)); ?>">
-            <meta itemprop="image" content="<?php if (is_single() || is_page()) {
-                if ($mdx_post_img !== false && $mdx_post_img[0] != "") {
-                    echo $mdx_post_img[0];
-                } else {
-                    echo "";
-                }
-            } else {
-                echo $mdx_index_img;
-            } ?>">
-        <?php }
+        <meta name="twitter:image" content="<?php echo $index_image; ?>">
+        <meta itemprop="name" content="<?php echo $title; ?>">
+        <meta itemprop="image" content="<?php echo $index_image; ?>">
+        <?php
         if ($mdx_des !== '') {
             if ($mdx_a_des === 'true') {
                 if (is_single() || is_page()) {
@@ -173,5 +130,6 @@
         <meta name="mdx-main-color" content="<?php echo $mdx_theme_color; ?>">
     <?php } ?>
     <link rel="pingback" href="<?php bloginfo('pingback_url'); ?>">
-    <?php wp_head(); ?><?php echo htmlspecialchars_decode(mdx_get_option('mdx_head_js')); ?>
+    <?php wp_head(); ?>
+    <?php echo htmlspecialchars_decode(mdx_get_option('mdx_head_js')); ?>
 </head>

--- a/header.php
+++ b/header.php
@@ -58,7 +58,6 @@ if (is_single() || is_page()) {
     <?php } ?>
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <!-- Theme developed by AxtonYao -->
-    <meta name="author" content="AxtonYao" />
     <?php if (mdx_get_option('mdx_safari') == "true") { ?>
         <link rel="mask-icon" href="<?php echo mdx_get_option('mdx_svg'); ?>" color="<?php echo mdx_get_option('mdx_svg_color'); ?>">
     <?php } ?>
@@ -83,10 +82,14 @@ if (is_single() || is_page()) {
         <?php
         $mdx_des = mdx_get_option('mdx_seo_des');
         $mdx_s_key = mdx_get_option('mdx_seo_key');
-        $mdx_a_des = mdx_get_option('mdx_auto_des'); ?>
+        $mdx_a_des = mdx_get_option('mdx_auto_des');
+        $opt_mdx_share_twitter_username = mdx_get_option('mdx_share_twitter_username');?>
         <meta property="og:description" content="<?php echo $social_describe; ?>">
         <meta property="og:image" content="<?php echo $index_image; ?>">
         <meta name="twitter:card" content="<?php echo (is_single()||is_page())?(($opt_mdx_share_twitter_card=="summary"||$opt_mdx_share_twitter_card=="summary_large_image")?$opt_mdx_share_twitter_card:"summary"):"summary"; ?>">
+        <?php if(preg_match("/@?([A-Za-z0-9_]+)/i",$opt_mdx_share_twitter_username,$v_opt_mdx_share_twitter_username)>0){ ?>
+            <meta name="twitter:site" content="@<?php echo $v_opt_mdx_share_twitter_username[1]; ?>">
+        <?php } ?>
         <meta name="twitter:title" content="<?php echo $title; ?>">
         <meta name="twitter:description" content="<?php echo $social_describe; ?>">
         <meta name="twitter:url" content="<?php echo $mdx_current_url; ?>">

--- a/header.php
+++ b/header.php
@@ -1,91 +1,177 @@
 ﻿<!DOCTYPE html>
-<html <?php language_attributes();?>>
+<html <?php language_attributes(); ?>>
 <head>
-<meta charset="<?php bloginfo('charset');?>">
-<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=<?php if(mdx_get_option('mdx_allow_scale')=='false'){echo '1, user-scalable=no';}else{echo '5';}?>">
-<?php if(mdx_get_option('mdx_speed_pre')=='true' && !is_404()){?>
-<?php if(is_home()){$mdx_js_name2='js';}elseif(is_category()||is_archive()||is_search()){$mdx_js_name2='ac';}elseif(is_single()){$mdx_js_name2='post';}elseif(is_page()){$mdx_js_name2='page';}else{$mdx_js_name2='js';}
-global $files_root;
-?>
-<link rel="preload" href="<?php echo $files_root;?>/js/common.js?ver=<?php echo get_option("mdx_version_commit");?>" as="script">
-<link rel="preload" href="<?php echo $files_root;?>/js/<?php echo $mdx_js_name2?>.js?ver=<?php echo get_option("mdx_version_commit");?>" as="script">
-<link rel="preload" href="<?php echo $files_root;?>/mdui/icons/material-icons/<?php if(mdx_get_option("mdx_md2")=="false"){ ?>MaterialIcons-Regular.woff2<?php }else{ ?>material_2_icon_font.woff2<?php } ?>" as="font" type="font/woff2" crossorigin>
-<?php if(mdx_get_option('mdx_md2')=="true" && mdx_get_option('mdx_md2_font')=="true"){?>
-<link rel="preload" href="<?php echo $files_root;?>/fonts/Montserrat-Regular.woff2" as="font" type="font/woff2" crossorigin>
-<link rel="preload" href="<?php echo $files_root;?>/fonts/Montserrat-SemiBold.woff2" as="font" type="font/woff2" crossorigin>
-<?php }}?>
-<meta http-equiv="X-UA-Compatible" content="IE=edge">
-<?php if(mdx_get_option('mdx_safari')=="true"){?>
-<link rel="mask-icon" href="<?php echo mdx_get_option('mdx_svg');?>" color="<?php echo mdx_get_option('mdx_svg_color');?>">
-<?php }?>
-<?php if(mdx_get_option("mdx_title_med") == "diy"){?>
-<title itemprop="name"><?php global $page, $paged;wp_title('-', true, 'right');
-bloginfo('name');$site_description = get_bloginfo('description', 'display');
-if($site_description && (is_home() || is_front_page())) echo " - $site_description";if($paged >= 2 || $page >= 2) echo ' - '.sprintf(__('第 %s 页'), max($paged, $page));?>
-</title>
-<?php }?>
-<?php if(is_single() || is_page()){
-    if(function_exists('get_query_var')){
-        $cpage = intval(get_query_var('cpage'));
-        $commentPage = intval(get_query_var('comment-page'));
-    }
-    if(!empty($cpage) || !empty($commentPage)){
-        echo '<meta name="robots" content="noindex, nofollow">';}}?>
-<?php if(!is_404()){?>
-<meta property="og:title" content="<?php global $page, $paged;wp_title('-', true, 'right');
-bloginfo('name');$site_description = get_bloginfo('description', 'display');if($site_description && (is_home() || is_front_page())) echo " - $site_description";if($paged >= 2 || $page >= 2) echo ' - '.sprintf(__('第 %s 页'), max($paged, $page));?>">
-<meta property="og:type" content="article">
-<meta property="og:url" content="<?php global $wp;$mdx_current_url=mdx_get_now_url(is_single(), isset($post) ? (int)$post->ID : 0);echo $mdx_current_url;?>">
-<?php
-$mdx_des=mdx_get_option('mdx_seo_des');
-$mdx_s_key=mdx_get_option('mdx_seo_key');
-$mdx_a_des=mdx_get_option('mdx_auto_des');?>
-<meta property="og:description" content="<?php if(is_single()||is_page()){if(post_password_required()){_e('这篇文章受密码保护，输入密码后才能查看。', 'mdx');}else{echo mdx_get_post_excerpt($post, 100);}}else if($mdx_des!=''){echo $mdx_des;}else{bloginfo('description', 'display');}?>">
-<?php $mdx_index_img=mdx_get_option('mdx_index_img');if(!((!(is_single()||is_page()))&&substr($mdx_index_img,0,6)=="--Bing")){?>
-<meta property="og:image" content="<?php if(is_single()||is_page()){$mdx_post_img=wp_get_attachment_image_src(get_post_thumbnail_id($post->ID),'full');if(isset($mdx_post_img[0])){echo $mdx_post_img[0];}else{echo "";}}else{echo $mdx_index_img;}?>">
-<?php }?>
-<meta name="twitter:card" content="summary">
-<meta name="twitter:title" content="<?php wp_title('-', true, 'right');
-bloginfo('name');if($site_description && (is_home() || is_front_page())) echo " - $site_description";if($paged >= 2 || $page >= 2) echo ' - '.sprintf(__('第 %s 页'), max($paged, $page));?>">
-<meta name="twitter:description" content="<?php if(is_single()||is_page()){if(post_password_required()){_e('这篇文章受密码保护，输入密码后才能查看。', 'mdx');}else{echo mdx_get_post_excerpt($post, 100);}}else if($mdx_des!=''){echo $mdx_des;}else{bloginfo('description', 'display');}?>">
-<meta name="twitter:url" content="<?php echo $mdx_current_url;?>">
-<?php if(!((!(is_single()||is_page()))&&substr($mdx_index_img,0,6)=="--Bing")){?>
-<meta name="twitter:image" content="<?php if(is_single()||is_page()){if($mdx_post_img!==false&&$mdx_post_img[0]!=""){echo $mdx_post_img[0];}else{echo "";}}else{echo $mdx_index_img;}?>">
-<meta itemprop="name" content="<?php wp_title('-', true, 'right');
-bloginfo('name');if($site_description && (is_home() || is_front_page())) echo " - $site_description";if($paged >= 2 || $page >= 2) echo ' - '.sprintf(__('第 %s 页'), max($paged, $page));?>">
-<meta itemprop="image" content="<?php if(is_single()||is_page()){if($mdx_post_img!==false&&$mdx_post_img[0]!=""){echo $mdx_post_img[0];}else{echo "";}}else{echo $mdx_index_img;}?>">
-<?php }
-if($mdx_des!==''){
-    if($mdx_a_des==='true'){
-        if(is_single()||is_page()){?>
-            <meta name="description" itemprop="description" content="<?php if(post_password_required()){_e('这篇文章受密码保护，输入密码后才能查看。', 'mdx');}else{echo mdx_get_post_excerpt($post, 100);}?>">
-        <?php }else{?>
-            <meta name="description" itemprop="description" content="<?php echo $mdx_des;?>">
+    <meta charset="<?php bloginfo('charset'); ?>">
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=<?php if (mdx_get_option('mdx_allow_scale') == 'false') {
+        echo '1, user-scalable=no';
+    } else {
+        echo '5';
+    } ?>">
+    <?php if (mdx_get_option('mdx_speed_pre') == 'true' && !is_404()) { ?>
+        <?php if (is_home()) {
+            $mdx_js_name2 = 'js';
+        } else if (is_category() || is_archive() || is_search()) {
+            $mdx_js_name2 = 'ac';
+        } else if (is_single()) {
+            $mdx_js_name2 = 'post';
+        } else if (is_page()) {
+            $mdx_js_name2 = 'page';
+        } else {
+            $mdx_js_name2 = 'js';
+        }
+        global $files_root;
+        ?>
+        <link rel="preload" href="<?php echo $files_root; ?>/js/common.js?ver=<?php echo get_option("mdx_version_commit"); ?>" as="script">
+        <link rel="preload" href="<?php echo $files_root; ?>/js/<?php echo $mdx_js_name2 ?>.js?ver=<?php echo get_option("mdx_version_commit"); ?>" as="script">
+        <link rel="preload" href="<?php echo $files_root; ?>/mdui/icons/material-icons/<?php if (mdx_get_option("mdx_md2") == "false") { ?>MaterialIcons-Regular.woff2<?php } else { ?>material_2_icon_font.woff2<?php } ?>" as="font" type="font/woff2" crossorigin>
+        <?php if (mdx_get_option('mdx_md2') == "true" && mdx_get_option('mdx_md2_font') == "true") { ?>
+            <link rel="preload" href="<?php echo $files_root; ?>/fonts/Montserrat-Regular.woff2" as="font" type="font/woff2" crossorigin>
+            <link rel="preload" href="<?php echo $files_root; ?>/fonts/Montserrat-SemiBold.woff2" as="font" type="font/woff2" crossorigin>
         <?php }
-    }else{?>
-        <meta name="description" itemprop="description" content="<?php echo $mdx_des;?>">
-    <?php }
-}
-if($mdx_s_key!=''){?>
-    <meta name="keywords" content="<?php bloginfo('name');echo ','.$mdx_s_key;?>">
-<?php }
-}
-if(mdx_get_option('mdx_chrome_color')=='true'){
-    $mdx_theme_color = mdx_get_option('mdx_styles_hex');
-    if(mdx_get_option('mdx_styles') === "white"){
-        $mdx_theme_color = "#ffffff";
+    } ?>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <?php if (mdx_get_option('mdx_safari') == "true") { ?>
+        <link rel="mask-icon" href="<?php echo mdx_get_option('mdx_svg'); ?>" color="<?php echo mdx_get_option('mdx_svg_color'); ?>">
+    <?php } ?>
+    <?php if (mdx_get_option("mdx_title_med") == "diy") { ?>
+        <title itemprop="name"><?php global $page, $paged;
+            wp_title('-', true, 'right');
+            bloginfo('name');
+            $site_description = get_bloginfo('description', 'display');
+            if ($site_description && (is_home() || is_front_page())) echo " - $site_description";
+            if ($paged >= 2 || $page >= 2) echo ' - ' . sprintf(__('第 %s 页'), max($paged, $page)); ?>
+        </title>
+    <?php } ?>
+    <?php if (is_single() || is_page()) {
+        if (function_exists('get_query_var')) {
+            $cpage = intval(get_query_var('cpage'));
+            $commentPage = intval(get_query_var('comment-page'));
+        }
+        if (!empty($cpage) || !empty($commentPage)) {
+            echo '<meta name="robots" content="noindex, nofollow">';
+        }
+    } ?>
+    <?php if (!is_404()) { ?>
+        <meta property="og:title" content="<?php global $page, $paged;
+        wp_title('-', true, 'right');
+        bloginfo('name');
+        $site_description = get_bloginfo('description', 'display');
+        if ($site_description && (is_home() || is_front_page())) echo " - $site_description";
+        if ($paged >= 2 || $page >= 2) echo ' - ' . sprintf(__('第 %s 页'), max($paged, $page)); ?>">
+        <meta property="og:type" content="article">
+        <meta property="og:url" content="<?php global $wp;
+        $mdx_current_url = mdx_get_now_url(is_single(), isset($post) ? (int)$post->ID : 0);
+        echo $mdx_current_url; ?>">
+        <?php
+        $mdx_des = mdx_get_option('mdx_seo_des');
+        $mdx_s_key = mdx_get_option('mdx_seo_key');
+        $mdx_a_des = mdx_get_option('mdx_auto_des'); ?>
+        <meta property="og:description" content="<?php if (is_single() || is_page()) {
+            if (post_password_required()) {
+                _e('这篇文章受密码保护，输入密码后才能查看。', 'mdx');
+            } else {
+                echo mdx_get_post_excerpt($post, 100);
+            }
+        } else if ($mdx_des != '') {
+            echo $mdx_des;
+        } else {
+            bloginfo('description', 'display');
+        } ?>">
+        <?php $mdx_index_img = mdx_get_option('mdx_index_img');
+        if (!((!(is_single() || is_page())) && substr($mdx_index_img, 0, 6) == "--Bing")) { ?>
+            <meta property="og:image" content="<?php if (is_single() || is_page()) {
+                $mdx_post_img = wp_get_attachment_image_src(get_post_thumbnail_id($post->ID), 'full');
+                if (isset($mdx_post_img[0])) {
+                    echo $mdx_post_img[0];
+                } else {
+                    echo "";
+                }
+            } else {
+                echo $mdx_index_img;
+            } ?>">
+        <?php } ?>
+        <meta name="twitter:card" content="summary">
+        <meta name="twitter:title" content="<?php wp_title('-', true, 'right');
+        bloginfo('name');
+        if ($site_description && (is_home() || is_front_page())) echo " - $site_description";
+        if ($paged >= 2 || $page >= 2) echo ' - ' . sprintf(__('第 %s 页'), max($paged, $page)); ?>">
+        <meta name="twitter:description" content="<?php if (is_single() || is_page()) {
+            if (post_password_required()) {
+                _e('这篇文章受密码保护，输入密码后才能查看。', 'mdx');
+            } else {
+                echo mdx_get_post_excerpt($post, 100);
+            }
+        } else if ($mdx_des != '') {
+            echo $mdx_des;
+        } else {
+            bloginfo('description', 'display');
+        } ?>">
+        <meta name="twitter:url" content="<?php echo $mdx_current_url; ?>">
+        <?php if (!((!(is_single() || is_page())) && substr($mdx_index_img, 0, 6) == "--Bing")) { ?>
+            <meta name="twitter:image" content="<?php if (is_single() || is_page()) {
+                if ($mdx_post_img !== false && $mdx_post_img[0] != "") {
+                    echo $mdx_post_img[0];
+                } else {
+                    echo "";
+                }
+            } else {
+                echo $mdx_index_img;
+            } ?>">
+            <meta itemprop="name" content="<?php wp_title('-', true, 'right');
+            bloginfo('name');
+            if ($site_description && (is_home() || is_front_page())) echo " - $site_description";
+            if ($paged >= 2 || $page >= 2) echo ' - ' . sprintf(__('第 %s 页'), max($paged, $page)); ?>">
+            <meta itemprop="image" content="<?php if (is_single() || is_page()) {
+                if ($mdx_post_img !== false && $mdx_post_img[0] != "") {
+                    echo $mdx_post_img[0];
+                } else {
+                    echo "";
+                }
+            } else {
+                echo $mdx_index_img;
+            } ?>">
+        <?php }
+        if ($mdx_des !== '') {
+            if ($mdx_a_des === 'true') {
+                if (is_single() || is_page()) {
+                    ?>
+                    <meta name="description" itemprop="description" content="<?php if (post_password_required()) {
+                        _e('这篇文章受密码保护，输入密码后才能查看。', 'mdx');
+                    } else {
+                        echo mdx_get_post_excerpt($post, 100);
+                    } ?>">
+                <?php } else {
+                    ?>
+                    <meta name="description" itemprop="description" content="<?php echo $mdx_des; ?>">
+                <?php }
+            } else {
+                ?>
+                <meta name="description" itemprop="description" content="<?php echo $mdx_des; ?>">
+            <?php }
+        }
+        if ($mdx_s_key != '') {
+            ?>
+            <meta name="keywords" content="<?php bloginfo('name');
+            echo ',' . $mdx_s_key; ?>">
+        <?php }
     }
-if(is_single()){
-    $mdx_theme_color_page = get_post_meta($post->ID, "mdx_styles_hex", true);
-if($mdx_theme_color_page!='def' && $mdx_theme_color_page!=''){
-    $mdx_theme_color = $mdx_theme_color_page;
-}
-if(get_post_meta($post->ID, "mdx_styles", true) === "white"){
-    $mdx_theme_color = "#ffffff";
-}}?>
-<meta name="theme-color" content="<?php echo $mdx_theme_color;?>">
-<meta name="mdx-main-color" content="<?php echo $mdx_theme_color;?>">
-<?php }?>
-<link rel="pingback" href="<?php bloginfo('pingback_url');?>">
-<?php wp_head(); ?><?php echo htmlspecialchars_decode(mdx_get_option('mdx_head_js'));?>
+    if (mdx_get_option('mdx_chrome_color') == 'true') {
+        $mdx_theme_color = mdx_get_option('mdx_styles_hex');
+        if (mdx_get_option('mdx_styles') === "white") {
+            $mdx_theme_color = "#ffffff";
+        }
+        if (is_single()) {
+            $mdx_theme_color_page = get_post_meta($post->ID, "mdx_styles_hex", true);
+            if ($mdx_theme_color_page != 'def' && $mdx_theme_color_page != '') {
+                $mdx_theme_color = $mdx_theme_color_page;
+            }
+            if (get_post_meta($post->ID, "mdx_styles", true) === "white") {
+                $mdx_theme_color = "#ffffff";
+            }
+        } ?>
+        <meta name="theme-color" content="<?php echo $mdx_theme_color; ?>">
+        <meta name="mdx-main-color" content="<?php echo $mdx_theme_color; ?>">
+    <?php } ?>
+    <link rel="pingback" href="<?php bloginfo('pingback_url'); ?>">
+    <?php wp_head(); ?><?php echo htmlspecialchars_decode(mdx_get_option('mdx_head_js')); ?>
 </head>

--- a/header.php
+++ b/header.php
@@ -3,6 +3,12 @@
 global $wp;
 global $files_root;
 global $page, $paged;
+/**
+ * @var string TwitterCard分享类型 summary|summary_large_image
+ * @see https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/abouts-cards Developer Document
+ * @see https://cards-dev.twitter.com/validator Site for Test
+ */
+$opt_mdx_share_twitter_card = mdx_get_option("mdx_share_twitter_card");
 
 // 获取当前页面Title
 $title = "";
@@ -15,7 +21,7 @@ if ($paged >= 2 || $page >= 2) $title .= ' - ' . sprintf(__('第 %s 页'), max($
 // 获取当前页面分享图
 $opt_mdx_index_img = mdx_get_option('mdx_index_img');
 $coverPicIsBing = (bool)substr($opt_mdx_index_img, 0, 6) == "--Bing";
-$index_image = !(!is_single() && !is_page() && $coverPicIsBing)?((is_single() || is_page())?(wp_get_attachment_image_src(get_post_thumbnail_id($post->ID), 'full')[0]??""):$opt_mdx_index_img):mdx_get_option('mdx_side_head');
+$index_image = !(!(is_single() || is_page()) && $coverPicIsBing)?((is_single() || is_page())?(wp_get_attachment_image_src(get_post_thumbnail_id($post->ID), 'full')[0]??""):$opt_mdx_index_img):mdx_get_option('mdx_side_head');
 
 // 获取当前页面社会分享描述
 $social_describe = "";
@@ -80,7 +86,7 @@ if (is_single() || is_page()) {
         $mdx_a_des = mdx_get_option('mdx_auto_des'); ?>
         <meta property="og:description" content="<?php echo $social_describe; ?>">
         <meta property="og:image" content="<?php echo $index_image; ?>">
-        <meta name="twitter:card" content="summary">
+        <meta name="twitter:card" content="<?php echo (is_single()||is_page())?(($opt_mdx_share_twitter_card=="summary"||$opt_mdx_share_twitter_card=="summary_large_image")?$opt_mdx_share_twitter_card:"summary"):"summary"; ?>">
         <meta name="twitter:title" content="<?php echo $title; ?>">
         <meta name="twitter:description" content="<?php echo $social_describe; ?>">
         <meta name="twitter:url" content="<?php echo $mdx_current_url; ?>">

--- a/header.php
+++ b/header.php
@@ -12,7 +12,7 @@ $opt_mdx_share_twitter_card = mdx_get_option("mdx_share_twitter_card");
 
 // 获取当前页面Title
 $title = "";
-$title .= wp_title('-', true, 'right');
+$title .= wp_title('-', false, 'right');
 $title .= get_bloginfo('name');
 $site_description = get_bloginfo('description', 'display');
 if ($site_description && (is_home() || is_front_page())) $title .= " - $site_description";

--- a/includes/default_value.php
+++ b/includes/default_value.php
@@ -32,6 +32,7 @@ $mdx_default_values = array(
     'mdx_speed_pre' => 'false',
     'mdx_share_area' => 'all',
     'mdx_share_twitter_card' => 'summary',
+    'mdx_share_twitter_username' => '',
     'mdx_hot_posts' => 'false',
     'mdx_hot_posts_get' => 'cat',
     'mdx_hot_posts_num' => '10',

--- a/includes/default_value.php
+++ b/includes/default_value.php
@@ -31,6 +31,7 @@ $mdx_default_values = array(
     'mdx_enhanced_ajax' => 'true',
     'mdx_speed_pre' => 'false',
     'mdx_share_area' => 'all',
+    'mdx_share_twitter_card' => 'summary',
     'mdx_hot_posts' => 'false',
     'mdx_hot_posts_get' => 'cat',
     'mdx_hot_posts_num' => '10',


### PR DESCRIPTION
## Set option: Twitter Card sharing type

* If [Description Card] is selected, the value of meta tag twitter:card will be "summary"
* If [large card with image] is selected, the value of meta tag twitter:card will be "summary_large_image"

Such as:
![1630414297](https://user-images.githubusercontent.com/51253685/131505669-b8474385-c06b-4aca-b557-180cbbb7b6f5.png)

* For more information, please check <https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/summary-card-with-large-image#reference>
* For test, please go <https://cards-dev.twitter.com/validator>

---

## Set option: Twitter username

* If the option is filled in and meets the rules: all pages will add the mata tag "twitter:site"

For more information, please check <https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/summary-card-with-large-image>

> This is a good way to indicate the source and the [erson in charge or company in charge of the website.

> Although it is marked that the `@` symbol cannot be added, no matter whether you add it or not, regular expressions will be used to determine the correct string.