### PR TITLE
Update: optimization of social sharing and higher scalability.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ node_modules
 .vscode
 
 dist
+
+yarn.lock

--- a/admin_fn.php
+++ b/admin_fn.php
@@ -1,845 +1,858 @@
 <?php
 settings_errors();
-$trueon = __('开启', 'mdx');
-$falseoff = __('关闭', 'mdx');
+$trueon   = __( '开启', 'mdx' );
+$falseoff = __( '关闭', 'mdx' );
 
-include('includes/cdn_version.php');
+include __DIR__ . '/includes/cdn_version.php';
+global $cdn_commit_version;
 
-wp_enqueue_script('my-tag', get_bloginfo('template_url') . '/js/admin_tag.js');
+wp_enqueue_script( 'my-tag', get_bloginfo( 'template_url' ) . '/js/admin_tag.js' );
 wp_enqueue_media();
 ?>
-<div class="wrap"><h1><?php _e('MDx 主题 - 功能', 'mdx'); ?></h1>
-    <?php
-    if ((isset($_POST['mdx_ref']) && $_POST['mdx_ref'] == 'true') && check_admin_referer('mdx_options_update')) {
-        global $files_root;
-        if (mdx_get_option('mdx_post_def_img_url') === $files_root . '/img/dpic.jpg') {
-            if ($_POST['mdx_use_cdn'] === 'jsdelivr') {
-                mdx_update_option('mdx_post_def_img_url', esc_url_raw('https://cdn.jsdelivr.net/gh/yrccondor/mdx@' . $cdn_commit_version . '/img/dpic.jpg'));
-            } else if ($_POST['mdx_use_cdn'] === 'custom') {
-                mdx_update_option('mdx_post_def_img_url', esc_url_raw(mdx_get_option('mdx_custom_cdn_root') . '/img/dpic.jpg'));
-            } else {
-                mdx_update_option('mdx_post_def_img_url', esc_url_raw(get_template_directory_uri() . '/img/dpic.jpg'));
-            }
-        }
+<div class="wrap"><h1><?php _e( 'MDx 主题 - 功能', 'mdx' ); ?></h1>
+	<?php
+	if ( ( isset( $_POST['mdx_ref'] ) && $_POST['mdx_ref'] == 'true' ) && check_admin_referer( 'mdx_options_update' ) ) {
+		global $files_root;
+		if ( mdx_get_option( 'mdx_post_def_img_url' ) === $files_root . '/img/dpic.jpg' ) {
+			if ( $_POST['mdx_use_cdn'] === 'jsdelivr' ) {
+				mdx_update_option( 'mdx_post_def_img_url', esc_url_raw( 'https://cdn.jsdelivr.net/gh/yrccondor/mdx@' . $cdn_commit_version . '/img/dpic.jpg' ) );
+			} else if ( $_POST['mdx_use_cdn'] === 'custom' ) {
+				mdx_update_option( 'mdx_post_def_img_url', esc_url_raw( mdx_get_option( 'mdx_custom_cdn_root' ) . '/img/dpic.jpg' ) );
+			} else {
+				mdx_update_option( 'mdx_post_def_img_url', esc_url_raw( get_template_directory_uri() . '/img/dpic.jpg' ) );
+			}
+		}
 
-        mdx_update_option('mdx_install', sanitize_text_field($_POST['mdx_install']));
-        if (isset($_POST['mdx_night_style'])) {
-            mdx_update_option('mdx_night_style', $_POST['mdx_night_style']);
-        } else {
-            mdx_update_option('mdx_night_style', 'false');
-        }
-        if (isset($_POST['mdx_auto_night_style'])) {
-            mdx_update_option('mdx_auto_night_style', $_POST['mdx_auto_night_style']);
-        } else {
-            mdx_update_option('mdx_auto_night_style', 'false');
-        }
-        mdx_update_option('mdx_notice', htmlentities(stripslashes($_POST['mdx_notice'])));
-        mdx_update_option('mdx_open_side', sanitize_text_field($_POST['mdx_open_side']));
-        mdx_update_option('mdx_widget', sanitize_text_field($_POST['mdx_widget']));
-        mdx_update_option('mdx_cookie', htmlentities(stripslashes($_POST['mdx_cookie'])));
-        mdx_update_option('mdx_cookie_flag', sanitize_text_field($_POST['mdx_cookie_flag']));
-        mdx_update_option('mdx_allow_scale', sanitize_text_field($_POST['mdx_allow_scale']));
-        mdx_update_option('mdx_reduce_motion', sanitize_text_field($_POST['mdx_reduce_motion']));
-        mdx_update_option('mdx_img_box', sanitize_text_field($_POST['mdx_img_box']));
-        mdx_update_option('mdx_img_box_show_alt', sanitize_text_field($_POST['mdx_img_box_show_alt']));
-        mdx_update_option('mdx_img_box_opacity', sanitize_text_field($_POST['mdx_img_box_opacity']));
-        mdx_update_option("mdx_readmore", sanitize_text_field($_POST['mdx_readmore']));
-        mdx_update_option("mdx_post_money", esc_url_raw($_POST['mdx_post_money']));
-        mdx_update_option('mdx_read_pro', sanitize_text_field($_POST['mdx_read_pro']));
-        mdx_update_option('mdx_auto_scroll', sanitize_text_field($_POST['mdx_auto_scroll']));
-        mdx_update_option('mdx_click_status', sanitize_text_field($_POST['mdx_click_status']));
-        mdx_update_option('mdx_toc', sanitize_text_field($_POST['mdx_toc']));
-        mdx_update_option('mdx_toc_preview', sanitize_text_field($_POST['mdx_toc_preview']));
-        mdx_update_option('mdx_load_pro', sanitize_text_field($_POST['mdx_load_pro']));
-        mdx_update_option('mdx_post_list_click_area', sanitize_text_field($_POST['mdx_post_list_click_area']));
-        mdx_update_option('mdx_post_list_1', sanitize_text_field($_POST['mdx_post_list_1']));
-        mdx_update_option('mdx_post_list_2', sanitize_text_field($_POST['mdx_post_list_2']));
-        mdx_update_option('mdx_post_list_3', sanitize_text_field($_POST['mdx_post_list_3']));
-        mdx_update_option('mdx_post_edit_time', sanitize_text_field($_POST['mdx_post_edit_time']));
-        mdx_update_option('mdx_author_card', sanitize_text_field($_POST['mdx_author_card']));
-        mdx_update_option("mdx_lazy_load_mode", sanitize_text_field($_POST['mdx_lazy_load_mode']));
-        mdx_update_option("mdx_lazyload_fallback", sanitize_text_field($_POST['mdx_lazyload_fallback']));
-        mdx_update_option("mdx_enhanced_ajax", sanitize_text_field($_POST['mdx_enhanced_ajax']));
-        mdx_update_option('mdx_speed_pre', sanitize_text_field($_POST['mdx_speed_pre']));
-        mdx_update_option('mdx_share_area', sanitize_text_field($_POST['mdx_share_area']));
-        mdx_update_option('mdx_share_twitter_card', sanitize_text_field($_POST['mdx_share_twitter_card'])??"summary");
-        mdx_update_option('mdx_share_twitter_username', sanitize_text_field($_POST['mdx_share_twitter_username']));
-        mdx_update_option('mdx_hot_posts', sanitize_text_field($_POST['mdx_hot_posts']));
-        mdx_update_option('mdx_hot_posts_get', sanitize_text_field($_POST['mdx_hot_posts_get']));
-        mdx_update_option('mdx_hot_posts_num', sanitize_text_field($_POST['mdx_hot_posts_num']));
-        mdx_update_option('mdx_hot_posts_cat', sanitize_text_field($_POST['mdx_hot_posts_cat']));
-        mdx_update_option('mdx_hot_posts_text', sanitize_text_field($_POST['mdx_hot_posts_text']));
-        mdx_update_option('mdx_all_posts_text', sanitize_text_field($_POST['mdx_all_posts_text']));
-        mdx_update_option('mdx_you_may_like', sanitize_text_field($_POST['mdx_you_may_like']));
-        mdx_update_option('mdx_you_may_like_num', sanitize_text_field($_POST['mdx_you_may_like_num']));
-        mdx_update_option('mdx_you_may_like_way', sanitize_text_field($_POST['mdx_you_may_like_way']));
-        mdx_update_option('mdx_you_may_like_text', sanitize_text_field($_POST['mdx_you_may_like_text']));
-        mdx_update_option('mdx_real_search', sanitize_text_field($_POST['mdx_real_search']));
-        mdx_update_option('mdx_submit_comment', sanitize_text_field($_POST['mdx_submit_comment']));
-        mdx_update_option('mdx_comment_ajax', sanitize_text_field($_POST['mdx_comment_ajax']));
-        mdx_update_option('mdx_comment_emj', sanitize_text_field($_POST['mdx_comment_emj']));
-        mdx_update_option('mdx_ad', htmlentities(stripslashes($_POST['mdx_ad'])));
-        mdx_update_option('mdx_logged_in_ad', sanitize_text_field($_POST['mdx_logged_in_ad']));
-        mdx_update_option('mdx_seo_key', sanitize_text_field($_POST['mdx_seo_key']));
-        mdx_update_option('mdx_auto_des', sanitize_text_field($_POST['mdx_auto_des']));
-        mdx_update_option('mdx_seo_des', htmlentities(stripslashes($_POST['mdx_seo_des'])));
-        mdx_update_option('mdx_head_js', htmlentities(stripslashes($_POST['mdx_head_js'])));
-        mdx_update_option('mdx_footer_js', htmlentities(stripslashes($_POST['mdx_footer_js'])));
-        mdx_update_option('mdx_icp_num', sanitize_text_field($_POST['mdx_icp_num']));
-        mdx_update_option('mdx_wangan_num', sanitize_text_field($_POST['mdx_wangan_num']));
-        mdx_update_option('mdx_use_cdn', sanitize_text_field($_POST['mdx_use_cdn']));
-        mdx_update_option('mdx_custom_cdn_root', esc_url_raw($_POST['mdx_custom_cdn_root']));
-        mdx_update_option('mdx_jquery', sanitize_text_field($_POST['mdx_jquery']));
-        ?>
+		mdx_update_option( 'mdx_install', sanitize_text_field( $_POST['mdx_install'] ) );
+		if ( isset( $_POST['mdx_night_style'] ) ) {
+			mdx_update_option( 'mdx_night_style', $_POST['mdx_night_style'] );
+		} else {
+			mdx_update_option( 'mdx_night_style', 'false' );
+		}
+		if ( isset( $_POST['mdx_auto_night_style'] ) ) {
+			mdx_update_option( 'mdx_auto_night_style', $_POST['mdx_auto_night_style'] );
+		} else {
+			mdx_update_option( 'mdx_auto_night_style', 'false' );
+		}
+		mdx_update_option( 'mdx_notice', htmlentities( stripslashes( $_POST['mdx_notice'] ) ) );
+		mdx_update_option( 'mdx_open_side', sanitize_text_field( $_POST['mdx_open_side'] ) );
+		mdx_update_option( 'mdx_widget', sanitize_text_field( $_POST['mdx_widget'] ) );
+		mdx_update_option( 'mdx_cookie', htmlentities( stripslashes( $_POST['mdx_cookie'] ) ) );
+		mdx_update_option( 'mdx_cookie_flag', sanitize_text_field( $_POST['mdx_cookie_flag'] ) );
+		mdx_update_option( 'mdx_allow_scale', sanitize_text_field( $_POST['mdx_allow_scale'] ) );
+		mdx_update_option( 'mdx_reduce_motion', sanitize_text_field( $_POST['mdx_reduce_motion'] ) );
+		mdx_update_option( 'mdx_img_box', sanitize_text_field( $_POST['mdx_img_box'] ) );
+		mdx_update_option( 'mdx_img_box_show_alt', sanitize_text_field( $_POST['mdx_img_box_show_alt'] ) );
+		mdx_update_option( 'mdx_img_box_opacity', sanitize_text_field( $_POST['mdx_img_box_opacity'] ) );
+		mdx_update_option( "mdx_readmore", sanitize_text_field( $_POST['mdx_readmore'] ) );
+		mdx_update_option( "mdx_post_money", esc_url_raw( $_POST['mdx_post_money'] ) );
+		mdx_update_option( 'mdx_read_pro', sanitize_text_field( $_POST['mdx_read_pro'] ) );
+		mdx_update_option( 'mdx_auto_scroll', sanitize_text_field( $_POST['mdx_auto_scroll'] ) );
+		mdx_update_option( 'mdx_click_status', sanitize_text_field( $_POST['mdx_click_status'] ) );
+		mdx_update_option( 'mdx_toc', sanitize_text_field( $_POST['mdx_toc'] ) );
+		mdx_update_option( 'mdx_toc_preview', sanitize_text_field( $_POST['mdx_toc_preview'] ) );
+		mdx_update_option( 'mdx_load_pro', sanitize_text_field( $_POST['mdx_load_pro'] ) );
+		mdx_update_option( 'mdx_post_list_click_area', sanitize_text_field( $_POST['mdx_post_list_click_area'] ) );
+		mdx_update_option( 'mdx_post_list_1', sanitize_text_field( $_POST['mdx_post_list_1'] ) );
+		mdx_update_option( 'mdx_post_list_2', sanitize_text_field( $_POST['mdx_post_list_2'] ) );
+		mdx_update_option( 'mdx_post_list_3', sanitize_text_field( $_POST['mdx_post_list_3'] ) );
+		mdx_update_option( 'mdx_post_edit_time', sanitize_text_field( $_POST['mdx_post_edit_time'] ) );
+		mdx_update_option( 'mdx_author_card', sanitize_text_field( $_POST['mdx_author_card'] ) );
+		mdx_update_option( "mdx_lazy_load_mode", sanitize_text_field( $_POST['mdx_lazy_load_mode'] ) );
+		mdx_update_option( "mdx_lazyload_fallback", sanitize_text_field( $_POST['mdx_lazyload_fallback'] ) );
+		mdx_update_option( "mdx_enhanced_ajax", sanitize_text_field( $_POST['mdx_enhanced_ajax'] ) );
+		mdx_update_option( 'mdx_speed_pre', sanitize_text_field( $_POST['mdx_speed_pre'] ) );
+		mdx_update_option( 'mdx_share_area', sanitize_text_field( $_POST['mdx_share_area'] ) );
+		mdx_update_option( 'mdx_share_twitter_card', sanitize_text_field( $_POST['mdx_share_twitter_card'] ) ?? "summary" );
+		mdx_update_option( 'mdx_share_twitter_username', sanitize_text_field( $_POST['mdx_share_twitter_username'] ) );
+		mdx_update_option( 'mdx_share_image', sanitize_text_field( $_POST['mdx_share_image'] ) );
+		mdx_update_option( 'mdx_hot_posts', sanitize_text_field( $_POST['mdx_hot_posts'] ) );
+		mdx_update_option( 'mdx_hot_posts_get', sanitize_text_field( $_POST['mdx_hot_posts_get'] ) );
+		mdx_update_option( 'mdx_hot_posts_num', sanitize_text_field( $_POST['mdx_hot_posts_num'] ) );
+		mdx_update_option( 'mdx_hot_posts_cat', sanitize_text_field( $_POST['mdx_hot_posts_cat'] ) );
+		mdx_update_option( 'mdx_hot_posts_text', sanitize_text_field( $_POST['mdx_hot_posts_text'] ) );
+		mdx_update_option( 'mdx_all_posts_text', sanitize_text_field( $_POST['mdx_all_posts_text'] ) );
+		mdx_update_option( 'mdx_you_may_like', sanitize_text_field( $_POST['mdx_you_may_like'] ) );
+		mdx_update_option( 'mdx_you_may_like_num', sanitize_text_field( $_POST['mdx_you_may_like_num'] ) );
+		mdx_update_option( 'mdx_you_may_like_way', sanitize_text_field( $_POST['mdx_you_may_like_way'] ) );
+		mdx_update_option( 'mdx_you_may_like_text', sanitize_text_field( $_POST['mdx_you_may_like_text'] ) );
+		mdx_update_option( 'mdx_real_search', sanitize_text_field( $_POST['mdx_real_search'] ) );
+		mdx_update_option( 'mdx_submit_comment', sanitize_text_field( $_POST['mdx_submit_comment'] ) );
+		mdx_update_option( 'mdx_comment_ajax', sanitize_text_field( $_POST['mdx_comment_ajax'] ) );
+		mdx_update_option( 'mdx_comment_emj', sanitize_text_field( $_POST['mdx_comment_emj'] ) );
+		mdx_update_option( 'mdx_ad', htmlentities( stripslashes( $_POST['mdx_ad'] ) ) );
+		mdx_update_option( 'mdx_logged_in_ad', sanitize_text_field( $_POST['mdx_logged_in_ad'] ) );
+		mdx_update_option( 'mdx_seo_key', sanitize_text_field( $_POST['mdx_seo_key'] ) );
+		mdx_update_option( 'mdx_auto_des', sanitize_text_field( $_POST['mdx_auto_des'] ) );
+		mdx_update_option( 'mdx_seo_des', htmlentities( stripslashes( $_POST['mdx_seo_des'] ) ) );
+		mdx_update_option( 'mdx_head_js', htmlentities( stripslashes( $_POST['mdx_head_js'] ) ) );
+		mdx_update_option( 'mdx_footer_js', htmlentities( stripslashes( $_POST['mdx_footer_js'] ) ) );
+		mdx_update_option( 'mdx_icp_num', sanitize_text_field( $_POST['mdx_icp_num'] ) );
+		mdx_update_option( 'mdx_wangan_num', sanitize_text_field( $_POST['mdx_wangan_num'] ) );
+		mdx_update_option( 'mdx_use_cdn', sanitize_text_field( $_POST['mdx_use_cdn'] ) );
+		mdx_update_option( 'mdx_custom_cdn_root', esc_url_raw( $_POST['mdx_custom_cdn_root'] ) );
+		mdx_update_option( 'mdx_jquery', sanitize_text_field( $_POST['mdx_jquery'] ) );
+		?>
         <div class="notice notice-success is-dismissible">
-            <p><?php _e('设置已保存。', 'mdx'); ?></p>
+            <p><?php _e( '设置已保存。', 'mdx' ); ?></p>
         </div>
-        <?php
-    } else if ((isset($_POST['mdx_ref']) && $_POST['mdx_ref'] == 'true') && !(check_admin_referer('mdx_options_update'))) {
-        ?>
+		<?php
+	} else if ( ( isset( $_POST['mdx_ref'] ) && $_POST['mdx_ref'] == 'true' ) && ! ( check_admin_referer( 'mdx_options_update' ) ) ) {
+		?>
         <div class="notice notice-error is-dismissible">
-            <p><?php _e('更改未能保存。', 'mdx'); ?></p>
+            <p><?php _e( '更改未能保存。', 'mdx' ); ?></p>
         </div>
-        <?php
-    } ?>
-    <?php if (get_option('mdx_new_ver') != get_option('mdx_version')) { ?>
+		<?php
+	} ?>
+	<?php if ( get_option( 'mdx_new_ver' ) != get_option( 'mdx_version' ) ) { ?>
         <div class="notice notice-info is-dismissible">
-            <p><?php _e('MDx 已发布新版本 ', 'mdx');echo get_option('mdx_new_ver');_e('。<a href="./admin.php?page=mdx_about">重新检查</a>', 'mdx'); ?></p>
+            <p><?php _e( 'MDx 已发布新版本 ', 'mdx' );
+				echo get_option( 'mdx_new_ver' );
+				_e( '。<a href="./admin.php?page=mdx_about">重新检查</a>', 'mdx' ); ?></p>
         </div>
-    <?php }
-    if (!defined('ALU_VERSION')) {
-        define('ALU_VERSION', '1.0.6');
-    }
-    if (ALU_VERSION !== '1.0.6') {
-        ?>
+	<?php }
+	if ( ! defined( 'ALU_VERSION' ) ) {
+		define( 'ALU_VERSION', '1.0.6' );
+	}
+	if ( ALU_VERSION !== '1.0.6' ) {
+		?>
         <div class="notice notice-warning is-dismissible">
-            <p><?php _e('你似乎正在使用旧版本的 Alu 表情插件。这与 MDx 2.x 不兼容，你需要前往 <a href="https://doc.flyhigher.top/mdx/zh-CN/config/emoji-in-comment/" target="_blank">MDx 文档</a> 下载安装新版插件。', 'mdx'); ?></p>
+            <p><?php _e( '你似乎正在使用旧版本的 Alu 表情插件。这与 MDx 2.x 不兼容，你需要前往 <a href="https://doc.flyhigher.top/mdx/zh-CN/config/emoji-in-comment/" target="_blank">MDx 文档</a> 下载安装新版插件。', 'mdx' ); ?></p>
         </div>
-    <?php } ?>
+	<?php } ?>
     <nav class="nav-tab-wrapper wp-clearfix" aria-label="Secondary menu">
-        <a href="#" class="nav-tab nav-tab-active mdx-admin-nav" id="mdx-admin-nav-post"><?php _e('文章页', 'mdx'); ?></a>
-        <a href="#" class="nav-tab mdx-admin-nav" id="mdx-admin-nav-post-list"><?php _e('文章列表', 'mdx'); ?></a>
-        <a href="#" class="nav-tab mdx-admin-nav" id="mdx-admin-nav-toc"><?php _e('目录', 'mdx'); ?></a>
-        <a href="#" class="nav-tab mdx-admin-nav" id="mdx-admin-nav-suggestion"><?php _e('推荐文章', 'mdx'); ?></a>
-        <a href="#" class="nav-tab mdx-admin-nav" id="mdx-admin-nav-comment"><?php _e('评论', 'mdx'); ?></a>
-        <a href="#" class="nav-tab mdx-admin-nav" id="mdx-admin-nav-lazyload"><?php _e('Lazyload', 'mdx'); ?></a>
-        <a href="#" class="nav-tab mdx-admin-nav" id="mdx-admin-nav-accessibility"><?php _e('无障碍', 'mdx'); ?></a>
-        <a href="#" class="nav-tab mdx-admin-nav" id="mdx-admin-nav-ad"><?php _e('广告', 'mdx'); ?></a>
-        <a href="#" class="nav-tab mdx-admin-nav" id="mdx-admin-nav-night-mode"><?php _e('夜间模式', 'mdx'); ?></a>
-        <a href="#" class="nav-tab mdx-admin-nav" id="mdx-admin-nav-seo"><?php _e('SEO', 'mdx'); ?></a>
-        <a href="#" class="nav-tab mdx-admin-nav" id="mdx-admin-nav-cdn"><?php _e('CDN', 'mdx'); ?></a>
-        <a href="#" class="nav-tab mdx-admin-nav" id="mdx-admin-nav-script"><?php _e('脚本', 'mdx'); ?></a>
-        <a href="#" class="nav-tab mdx-admin-nav" id="mdx-admin-nav-others"><?php _e('杂项', 'mdx'); ?></a>
+        <a href="#" class="nav-tab nav-tab-active mdx-admin-nav" id="mdx-admin-nav-post"><?php _e( '文章页', 'mdx' ); ?></a>
+        <a href="#" class="nav-tab mdx-admin-nav" id="mdx-admin-nav-post-list"><?php _e( '文章列表', 'mdx' ); ?></a>
+        <a href="#" class="nav-tab mdx-admin-nav" id="mdx-admin-nav-toc"><?php _e( '目录', 'mdx' ); ?></a>
+        <a href="#" class="nav-tab mdx-admin-nav" id="mdx-admin-nav-suggestion"><?php _e( '推荐文章', 'mdx' ); ?></a>
+        <a href="#" class="nav-tab mdx-admin-nav" id="mdx-admin-nav-comment"><?php _e( '评论', 'mdx' ); ?></a>
+        <a href="#" class="nav-tab mdx-admin-nav" id="mdx-admin-nav-lazyload"><?php _e( 'Lazyload', 'mdx' ); ?></a>
+        <a href="#" class="nav-tab mdx-admin-nav" id="mdx-admin-nav-accessibility"><?php _e( '无障碍', 'mdx' ); ?></a>
+        <a href="#" class="nav-tab mdx-admin-nav" id="mdx-admin-nav-ad"><?php _e( '广告', 'mdx' ); ?></a>
+        <a href="#" class="nav-tab mdx-admin-nav" id="mdx-admin-nav-night-mode"><?php _e( '夜间模式', 'mdx' ); ?></a>
+        <a href="#" class="nav-tab mdx-admin-nav" id="mdx-admin-nav-seo"><?php _e( 'SEO', 'mdx' ); ?></a>
+        <a href="#" class="nav-tab mdx-admin-nav" id="mdx-admin-nav-cdn"><?php _e( 'CDN', 'mdx' ); ?></a>
+        <a href="#" class="nav-tab mdx-admin-nav" id="mdx-admin-nav-script"><?php _e( '脚本', 'mdx' ); ?></a>
+        <a href="#" class="nav-tab mdx-admin-nav" id="mdx-admin-nav-others"><?php _e( '杂项', 'mdx' ); ?></a>
     </nav>
     <form method="post" action="">
-        <?php
-        wp_nonce_field('mdx_options_update');
-        ?>
+		<?php
+		wp_nonce_field( 'mdx_options_update' );
+		?>
         <input type='hidden' name='mdx_ref' value='true'>
         <table class="form-table">
             <tbody class="mdx-admin-section mdx-admin-section-active" id="mdx-admin-nav-post-section">
-                <tr>
-                    <th scope="row"><?php _e('ImgBox', 'mdx'); ?></th>
-                    <td>
-                        <?php $mdx_v_img_box = mdx_get_option('mdx_img_box'); ?>
-                        <fieldset>
-                            <label><input type="radio" class="mdx_img_box" name="mdx_img_box" value="true" <?php if ($mdx_v_img_box == 'true'){ ?>checked="checked"<?php } ?>> <?php echo $trueon; ?>
-                            </label><br>
-                            <label><input type="radio" class="mdx_img_box" name="mdx_img_box" value="false" <?php if ($mdx_v_img_box == 'false'){ ?>checked="checked"<?php } ?>> <?php echo $falseoff; ?>
-                            </label><br>
-                            <p class="description"><?php _e('开启后，对于文章内包裹在指向自身的链接中的图片可点击查看大图。', 'mdx'); ?></p>
-                        </fieldset>
-                    </td>
-                </tr>
-                <tr>
-                    <th scope="row"><?php _e('ImgBox 显示描述文本', 'mdx'); ?></th>
-                    <td>
-                        <?php $mdx_v_img_box_show_alt = mdx_get_option('mdx_img_box_show_alt'); ?>
-                        <fieldset>
-                            <label><input type="radio" class="mdx_img_box_alt" name="mdx_img_box_show_alt" value="true" <?php if ($mdx_v_img_box_show_alt == 'true'){ ?>checked="checked"<?php } ?>> <?php echo $trueon; ?>
-                            </label><br>
-                            <label><input type="radio" class="mdx_img_box_alt" name="mdx_img_box_show_alt" value="false" <?php if ($mdx_v_img_box_show_alt == 'false'){ ?>checked="checked"<?php } ?>> <?php echo $falseoff; ?>
-                            </label><br>
-                            <p class="description"><?php _e('开启后，点击查看大图时，如果图片的 <code>alt</code> 属性不为空，图片下方将会显示 <code>alt</code> 属性内的文本。', 'mdx'); ?></p>
-                        </fieldset>
-                    </td>
-                </tr>
-                <tr>
-                    <th scope="row"><?php _e('ImgBox 背景', 'mdx'); ?></th>
-                    <td>
-                        <?php $mdx_v_img_box_opacity = mdx_get_option('mdx_img_box_opacity'); ?>
-                        <fieldset>
-                            <label><input type="radio" class="mdx_img_box_opacity" name="mdx_img_box_opacity" value="true" <?php if ($mdx_v_img_box_opacity == 'true'){ ?>checked="checked"<?php } ?>> <?php _e('纯色', 'mdx'); ?>
-                            </label><br>
-                            <label><input type="radio" class="mdx_img_box_opacity" name="mdx_img_box_opacity" value="false" <?php if ($mdx_v_img_box_opacity == 'false'){ ?>checked="checked"<?php } ?>> <?php _e('半透明', 'mdx'); ?>
-                            </label>
-                        </fieldset>
-                    </td>
-                </tr>
-                <tr>
-                    <th scope="row"><?php _e('赞赏二维码', 'mdx'); ?></th>
-                    <td>
-                        <input name="mdx_post_money" type="text" id="mdx_post_money"
-                            value="<?php echo esc_attr(mdx_get_option('mdx_post_money')) ?>" class="regular-text">
-                        <button type="button" id="insert-media-button" class="button"
-                                style="margin-top:5px;display:block"><?php _e('选择图片', 'mdx'); ?></button>
-                        <p class="description"><?php _e('你可以上传或指定你的媒体库中的图片作为赞赏二维码。当此空不为空时将在文章底部显示赞赏按钮。', 'mdx'); ?></p>
-                        <img id="img1" style="width:100%;max-width:300px;height:auto;margin-top:5px;"></img>
-                    </td>
-                </tr>
-                <tr>
-                    <th scope="row"><?php _e('阅读进度展示', 'mdx'); ?></th>
-                    <td>
-                        <?php $mdx_v_read_pro = mdx_get_option('mdx_read_pro'); ?>
-                        <fieldset>
-                            <label><input type="radio" name="mdx_read_pro" value="true" <?php if ($mdx_v_read_pro == 'true'){ ?>checked="checked"<?php } ?>> <?php echo $trueon; ?>
-                            </label><br>
-                            <label><input type="radio" name="mdx_read_pro" value="false" <?php if ($mdx_v_read_pro == 'false'){ ?>checked="checked"<?php } ?>> <?php echo $falseoff; ?>
-                            </label><br>
-                            <p class="description"><?php _e('开启后，会在文章/单独页面展示阅读进度。', 'mdx'); ?></p>
-                        </fieldset>
-                    </td>
-                </tr>
-                <tr>
-                    <th scope="row"><?php _e('转移设备时记录阅读进度', 'mdx'); ?></th>
-                    <td>
-                        <?php $mdx_v_auto_scroll = mdx_get_option('mdx_auto_scroll'); ?>
-                        <fieldset>
-                            <label><input type="radio" name="mdx_auto_scroll" value="true" <?php if ($mdx_v_auto_scroll == 'true'){ ?>checked="checked"<?php } ?>> <?php echo $trueon; ?>
-                            </label><br>
-                            <label><input type="radio" name="mdx_auto_scroll" value="false" <?php if ($mdx_v_auto_scroll == 'false'){ ?>checked="checked"<?php } ?>> <?php echo $falseoff; ?>
-                            </label><br>
-                            <p class="description"><?php _e('开启后，文章中通过二维码转移到其他设备阅读时会自动记录阅读进度并滚动。建议在网页加载速度较快时启用。', 'mdx'); ?></p>
-                        </fieldset>
-                    </td>
-                </tr>
-                <tr>
-                    <th scope="row"><?php _e('页面加载进度条', 'mdx'); ?></th>
-                    <td>
-                        <?php $mdx_v_load_pro = mdx_get_option('mdx_load_pro'); ?>
-                        <fieldset>
-                            <label><input type="radio" name="mdx_load_pro" value="true" <?php if ($mdx_v_load_pro == 'true'){ ?>checked="checked"<?php } ?>> <?php echo $trueon; ?>
-                            </label><br>
-                            <label><input type="radio" name="mdx_load_pro" value="false" <?php if ($mdx_v_load_pro == 'false'){ ?>checked="checked"<?php } ?>> <?php echo $falseoff; ?>
-                            </label><br>
-                            <p class="description"><?php _e('开启后，文章/单独页面加载时会在页面顶部显示加载进度条（仅动画，非真实进度），页面加载完成后消失。', 'mdx'); ?></p>
-                        </fieldset>
-                    </td>
-                </tr>
-                <tr>
-                    <th scope="row"><label for="mdx_post_edit_time"><?php _e('文章时间信息', 'mdx'); ?></label></th>
-                    <td>
-                        <?php $mdx_v_post_edit_time = mdx_get_option('mdx_post_edit_time'); ?>
-                        <select name="mdx_post_edit_time" id="mdx_post_edit_time">
-                            <option value="post" <?php if ($mdx_v_post_edit_time == 'post'){ ?>selected="selected"<?php } ?>><?php _e('发布时间', 'mdx'); ?></option>
-                            <option value="edit" <?php if ($mdx_v_post_edit_time == 'edit'){ ?>selected="selected"<?php } ?>><?php _e('最后编辑时间', 'mdx'); ?></option>
-                        </select>
-                    </td>
-                </tr>
-                <tr>
-                    <th scope="row"><?php _e('文末作者信息栏', 'mdx'); ?></th>
-                    <td>
-                        <?php $mdx_v_author_card = mdx_get_option('mdx_author_card'); ?>
-                        <fieldset>
-                            <label><input type="radio" name="mdx_author_card" value="true" <?php if ($mdx_v_author_card == 'true'){ ?>checked="checked"<?php } ?>> <?php echo $trueon; ?>
-                            </label><br>
-                            <label><input type="radio" name="mdx_author_card" value="false" <?php if ($mdx_v_author_card == 'false'){ ?>checked="checked"<?php } ?>> <?php echo $falseoff; ?>
-                            </label><br>
-                        </fieldset>
-                    </td>
-                </tr>
-                <tr>
-                    <th scope="row"><label for="mdx_share_area"><?php _e('分享到的服务商', 'mdx'); ?></label></th>
-                    <td>
-                        <?php $mdx_v_share_area = mdx_get_option('mdx_share_area'); ?>
-                        <select name="mdx_share_area" id="mdx_share_area">
-                            <option value="all" <?php if ($mdx_v_share_area == 'all'){ ?>selected="selected"<?php } ?>><?php _e('所有服务商', 'mdx'); ?></option>
-                            <option value="china" <?php if ($mdx_v_share_area == 'china'){ ?>selected="selected"<?php } ?>><?php _e('只有中国国内服务商', 'mdx'); ?></option>
-                            <option value="oversea" <?php if ($mdx_v_share_area == 'oversea'){ ?>selected="selected"<?php } ?>><?php _e('只有国际服务商', 'mdx'); ?></option>
-                        </select>
-                        <p class="description"><?php _e('指定你想提供给访问者的分享服务商。</p><ul><li><code>只有中国国内服务商</code>：提供 微博、微信、QQ、QQ 空间 的分享</li><li><code>只有国际服务商</code>：提供 Telegrame、Twitter、Facebook 的分享</li></ul><p>无论如何，“生成分享图”始终启用。', 'mdx'); ?></p>
-                    </td>
-                </tr>
-                <tr>
-                    <th scope="row"><label for="mdx_share_twitter_card"><?php _e('Twitter 分享类型', 'mdx'); ?></label></th>
-                    <td>
-                        <?php $mdx_v_share_twitter_card = mdx_get_option('mdx_share_twitter_card'); ?>
-                        <fieldset>
-                            <label>
-                                <input type="radio" name="mdx_share_twitter_card" value="summary" <?php if ($mdx_v_share_twitter_card == 'summary'){ ?>checked="checked"<?php } ?>> <?php _e("描述卡片","mdx"); ?>
-                            </label><br>
-                            <label>
-                                <input type="radio" name="mdx_share_twitter_card" value="summary_large_image" <?php if ($mdx_v_share_twitter_card == 'summary_large_image'){ ?>checked="checked"<?php } ?>> <?php _e("图片卡片","mdx"); ?>
-                            </label><br>
-                        </fieldset>
-                    </td>
-                </tr>
-                <tr>
-                    <th scope="row"><label for="mdx_share_twitter_username"><?php _e('Twitter 分享用户名', 'mdx'); ?></label></th>
-                    <td>
-                        <input name="mdx_share_twitter_username" type="text" id="mdx_share_twitter_username" value="<?php echo esc_attr(mdx_get_option('mdx_share_twitter_username')) ?>" class="regular-text">
-                        <p class="description"><?php _e('直接输入 Twitter 用户名，不要加入 <code>@<code>，网站链接分享至 Twitter 时会显示站点所有者为此账户。', 'mdx'); ?></p>
-                    </td>
-                </tr>
+            <tr>
+                <th scope="row"><?php _e( 'ImgBox', 'mdx' ); ?></th>
+                <td>
+					<?php $mdx_v_img_box = mdx_get_option( 'mdx_img_box' ); ?>
+                    <fieldset>
+                        <label><input type="radio" class="mdx_img_box" name="mdx_img_box" value="true" <?php if ( $mdx_v_img_box == 'true' ){ ?>checked="checked"<?php } ?>> <?php echo $trueon; ?>
+                        </label><br>
+                        <label><input type="radio" class="mdx_img_box" name="mdx_img_box" value="false" <?php if ( $mdx_v_img_box == 'false' ){ ?>checked="checked"<?php } ?>> <?php echo $falseoff; ?>
+                        </label><br>
+                        <p class="description"><?php _e( '开启后，对于文章内包裹在指向自身的链接中的图片可点击查看大图。', 'mdx' ); ?></p>
+                    </fieldset>
+                </td>
+            </tr>
+            <tr>
+                <th scope="row"><?php _e( 'ImgBox 显示描述文本', 'mdx' ); ?></th>
+                <td>
+					<?php $mdx_v_img_box_show_alt = mdx_get_option( 'mdx_img_box_show_alt' ); ?>
+                    <fieldset>
+                        <label><input type="radio" class="mdx_img_box_alt" name="mdx_img_box_show_alt" value="true" <?php if ( $mdx_v_img_box_show_alt == 'true' ){ ?>checked="checked"<?php } ?>> <?php echo $trueon; ?>
+                        </label><br>
+                        <label><input type="radio" class="mdx_img_box_alt" name="mdx_img_box_show_alt" value="false" <?php if ( $mdx_v_img_box_show_alt == 'false' ){ ?>checked="checked"<?php } ?>> <?php echo $falseoff; ?>
+                        </label><br>
+                        <p class="description"><?php _e( '开启后，点击查看大图时，如果图片的 <code>alt</code> 属性不为空，图片下方将会显示 <code>alt</code> 属性内的文本。', 'mdx' ); ?></p>
+                    </fieldset>
+                </td>
+            </tr>
+            <tr>
+                <th scope="row"><?php _e( 'ImgBox 背景', 'mdx' ); ?></th>
+                <td>
+					<?php $mdx_v_img_box_opacity = mdx_get_option( 'mdx_img_box_opacity' ); ?>
+                    <fieldset>
+                        <label><input type="radio" class="mdx_img_box_opacity" name="mdx_img_box_opacity" value="true" <?php if ( $mdx_v_img_box_opacity == 'true' ){ ?>checked="checked"<?php } ?>> <?php _e( '纯色', 'mdx' ); ?>
+                        </label><br>
+                        <label><input type="radio" class="mdx_img_box_opacity" name="mdx_img_box_opacity" value="false" <?php if ( $mdx_v_img_box_opacity == 'false' ){ ?>checked="checked"<?php } ?>> <?php _e( '半透明', 'mdx' ); ?>
+                        </label>
+                    </fieldset>
+                </td>
+            </tr>
+            <tr>
+                <th scope="row"><?php _e( '赞赏二维码', 'mdx' ); ?></th>
+                <td>
+                    <input name="mdx_post_money" type="text" id="mdx_post_money"
+                           value="<?php echo esc_attr( mdx_get_option( 'mdx_post_money' ) ) ?>" class="regular-text">
+                    <button type="button" id="insert-media-button" class="button"
+                            style="margin-top:5px;display:block"><?php _e( '选择图片', 'mdx' ); ?></button>
+                    <p class="description"><?php _e( '你可以上传或指定你的媒体库中的图片作为赞赏二维码。当此空不为空时将在文章底部显示赞赏按钮。', 'mdx' ); ?></p>
+                    <img id="img1" style="width:100%;max-width:300px;height:auto;margin-top:5px;">
+                </td>
+            </tr>
+            <tr>
+                <th scope="row"><?php _e( '阅读进度展示', 'mdx' ); ?></th>
+                <td>
+					<?php $mdx_v_read_pro = mdx_get_option( 'mdx_read_pro' ); ?>
+                    <fieldset>
+                        <label><input type="radio" name="mdx_read_pro" value="true" <?php if ( $mdx_v_read_pro == 'true' ){ ?>checked="checked"<?php } ?>> <?php echo $trueon; ?>
+                        </label><br>
+                        <label><input type="radio" name="mdx_read_pro" value="false" <?php if ( $mdx_v_read_pro == 'false' ){ ?>checked="checked"<?php } ?>> <?php echo $falseoff; ?>
+                        </label><br>
+                        <p class="description"><?php _e( '开启后，会在文章/单独页面展示阅读进度。', 'mdx' ); ?></p>
+                    </fieldset>
+                </td>
+            </tr>
+            <tr>
+                <th scope="row"><?php _e( '转移设备时记录阅读进度', 'mdx' ); ?></th>
+                <td>
+					<?php $mdx_v_auto_scroll = mdx_get_option( 'mdx_auto_scroll' ); ?>
+                    <fieldset>
+                        <label><input type="radio" name="mdx_auto_scroll" value="true" <?php if ( $mdx_v_auto_scroll == 'true' ){ ?>checked="checked"<?php } ?>> <?php echo $trueon; ?>
+                        </label><br>
+                        <label><input type="radio" name="mdx_auto_scroll" value="false" <?php if ( $mdx_v_auto_scroll == 'false' ){ ?>checked="checked"<?php } ?>> <?php echo $falseoff; ?>
+                        </label><br>
+                        <p class="description"><?php _e( '开启后，文章中通过二维码转移到其他设备阅读时会自动记录阅读进度并滚动。建议在网页加载速度较快时启用。', 'mdx' ); ?></p>
+                    </fieldset>
+                </td>
+            </tr>
+            <tr>
+                <th scope="row"><?php _e( '页面加载进度条', 'mdx' ); ?></th>
+                <td>
+					<?php $mdx_v_load_pro = mdx_get_option( 'mdx_load_pro' ); ?>
+                    <fieldset>
+                        <label><input type="radio" name="mdx_load_pro" value="true" <?php if ( $mdx_v_load_pro == 'true' ){ ?>checked="checked"<?php } ?>> <?php echo $trueon; ?>
+                        </label><br>
+                        <label><input type="radio" name="mdx_load_pro" value="false" <?php if ( $mdx_v_load_pro == 'false' ){ ?>checked="checked"<?php } ?>> <?php echo $falseoff; ?>
+                        </label><br>
+                        <p class="description"><?php _e( '开启后，文章/单独页面加载时会在页面顶部显示加载进度条（仅动画，非真实进度），页面加载完成后消失。', 'mdx' ); ?></p>
+                    </fieldset>
+                </td>
+            </tr>
+            <tr>
+                <th scope="row"><label for="mdx_post_edit_time"><?php _e( '文章时间信息', 'mdx' ); ?></label></th>
+                <td>
+					<?php $mdx_v_post_edit_time = mdx_get_option( 'mdx_post_edit_time' ); ?>
+                    <select name="mdx_post_edit_time" id="mdx_post_edit_time">
+                        <option value="post" <?php if ( $mdx_v_post_edit_time == 'post' ){ ?>selected="selected"<?php } ?>><?php _e( '发布时间', 'mdx' ); ?></option>
+                        <option value="edit" <?php if ( $mdx_v_post_edit_time == 'edit' ){ ?>selected="selected"<?php } ?>><?php _e( '最后编辑时间', 'mdx' ); ?></option>
+                    </select>
+                </td>
+            </tr>
+            <tr>
+                <th scope="row"><?php _e( '文末作者信息栏', 'mdx' ); ?></th>
+                <td>
+					<?php $mdx_v_author_card = mdx_get_option( 'mdx_author_card' ); ?>
+                    <fieldset>
+                        <label><input type="radio" name="mdx_author_card" value="true" <?php if ( $mdx_v_author_card == 'true' ){ ?>checked="checked"<?php } ?>> <?php echo $trueon; ?>
+                        </label><br>
+                        <label><input type="radio" name="mdx_author_card" value="false" <?php if ( $mdx_v_author_card == 'false' ){ ?>checked="checked"<?php } ?>> <?php echo $falseoff; ?>
+                        </label><br>
+                    </fieldset>
+                </td>
+            </tr>
+            <tr>
+                <th scope="row"><label for="mdx_share_area"><?php _e( '分享到的服务商', 'mdx' ); ?></label></th>
+                <td>
+					<?php $mdx_v_share_area = mdx_get_option( 'mdx_share_area' ); ?>
+                    <select name="mdx_share_area" id="mdx_share_area">
+                        <option value="all" <?php if ( $mdx_v_share_area == 'all' ){ ?>selected="selected"<?php } ?>><?php _e( '所有服务商', 'mdx' ); ?></option>
+                        <option value="china" <?php if ( $mdx_v_share_area == 'china' ){ ?>selected="selected"<?php } ?>><?php _e( '只有中国国内服务商', 'mdx' ); ?></option>
+                        <option value="oversea" <?php if ( $mdx_v_share_area == 'oversea' ){ ?>selected="selected"<?php } ?>><?php _e( '只有国际服务商', 'mdx' ); ?></option>
+                    </select>
+                    <p class="description"><?php _e( '指定你想提供给访问者的分享服务商。</p><ul><li><code>只有中国国内服务商</code>：提供 微博、微信、QQ、QQ 空间 的分享</li><li><code>只有国际服务商</code>：提供 Telegrame、Twitter、Facebook 的分享</li></ul><p>无论如何，“生成分享图”始终启用。', 'mdx' ); ?></p>
+                </td>
+            </tr>
+            <tr>
+                <th scope="row"><label for="mdx_share_twitter_card"><?php _e( 'Twitter 分享类型', 'mdx' ); ?></label></th>
+                <td>
+					<?php $mdx_v_share_twitter_card = mdx_get_option( 'mdx_share_twitter_card' ); ?>
+                    <fieldset>
+                        <label>
+                            <input type="radio" name="mdx_share_twitter_card" value="summary" <?php if ( $mdx_v_share_twitter_card == 'summary' ){ ?>checked="checked"<?php } ?>> <?php _e( "描述卡片", "mdx" ); ?>
+                        </label><br>
+                        <label>
+                            <input type="radio" name="mdx_share_twitter_card" value="summary_large_image" <?php if ( $mdx_v_share_twitter_card == 'summary_large_image' ){ ?>checked="checked"<?php } ?>> <?php _e( "图片卡片", "mdx" ); ?>
+                        </label><br>
+                    </fieldset>
+                </td>
+            </tr>
+            <tr>
+                <th scope="row"><label for="mdx_share_twitter_username"><?php _e( 'Twitter 分享用户名', 'mdx' ); ?></label>
+                </th>
+                <td>
+                    <input name="mdx_share_twitter_username" type="text" id="mdx_share_twitter_username" value="<?php echo esc_attr( mdx_get_option( 'mdx_share_twitter_username' ) ) ?>" class="regular-text">
+                    <p class="description"><?php _e( '直接输入 Twitter 用户名，不要加入 <code>@</code>，网站链接分享至 Twitter 时会显示站点所有者为此账户。', 'mdx' ); ?></p>
+                </td>
+            </tr>
+            <tr>
+                <th scope="row"><?php _e( '社会化分享默认图片', 'mdx' ); ?></th>
+                <td>
+                    <input name="mdx_share_image" type="text" id="mdx_share_image"
+                           value="<?php echo esc_attr( mdx_get_option( 'mdx_share_image' ) ) ?>" class="regular-text">
+                    <p class="description"><?php _e( '你可以上传或指定你的媒体库中的图片作为社会化分享默认图片。', 'mdx' ); ?></p>
+                </td>
+            </tr>
             </tbody>
 
             <tbody class="mdx-admin-section" id="mdx-admin-nav-post-list-section">
-                <tr>
-                    <th scope="row"><label for="mdx_readmore"><?php _e('“阅读更多”文本自定义', 'mdx'); ?></label></th>
-                    <td><input name="mdx_readmore" type="text" id="mdx_readmore"
-                            value="<?php echo esc_attr(mdx_get_option('mdx_readmore')) ?>" class="regular-text">
-                        <p class="description" id="mdx_footer"><?php _e('在此自定义“阅读更多”按钮上的文本。', 'mdx'); ?></p></td>
-                </tr>
-                <tr>
-                    <th scope="row"><label for="mdx_post_list_click_area"><?php _e('文章列表链接可点击区域', 'mdx'); ?></label></th>
-                    <td>
-                        <?php $mdx_v_post_list_click_area = mdx_get_option('mdx_post_list_click_area'); ?>
-                        <select name="mdx_post_list_click_area" id="mdx_post_list_click_area">
-                            <option value="title" <?php if ($mdx_v_post_list_click_area == 'title'){ ?>selected="selected"<?php } ?>><?php _e("仅标题", "mdx"); ?></option>
-                            <option value="pic" <?php if ($mdx_v_post_list_click_area == 'pic'){ ?>selected="selected"<?php } ?>><?php echo _e("标题和文章特色图像", "mdx"); ?></option>
-                        </select>
-                    </td>
-                </tr>
-                <tr>
-                    <th scope="row"><label for="mdx_post_list_1"><?php _e('文章列表详细信息 - 位置1', 'mdx'); ?></label></th>
-                    <td>
-                        <?php $mdx_v_post_list_1 = mdx_get_option('mdx_post_list_1'); ?>
-                        <?php
-                        $mdx_i18n_settings_1 = __('浏览量', 'mdx');
-                        $mdx_i18n_settings_2 = __('发表时间', 'mdx');
-                        $mdx_i18n_settings_3 = __('评论数', 'mdx');
-                        $mdx_i18n_settings_4 = __('空', 'mdx');
-                        ?>
-                        <select name="mdx_post_list_1" id="mdx_post_list_1">
-                            <option value="view" <?php if ($mdx_v_post_list_1 == 'view'){ ?>selected="selected"<?php } ?>><?php echo $mdx_i18n_settings_1; ?></option>
-                            <option value="time" <?php if ($mdx_v_post_list_1 == 'time'){ ?>selected="selected"<?php } ?>><?php echo $mdx_i18n_settings_2; ?></option>
-                            <option value="comments" <?php if ($mdx_v_post_list_1 == 'comments'){ ?>selected="selected"<?php } ?>><?php echo $mdx_i18n_settings_3; ?></option>
-                            <option value="blank" <?php if ($mdx_v_post_list_1 == 'blank'){ ?>selected="selected"<?php } ?>><?php echo $mdx_i18n_settings_4; ?></option>
-                        </select>
-                    </td>
-                </tr>
-                <tr>
-                    <th scope="row"><label for="mdx_post_list_2"><?php _e('文章列表详细信息 - 位置2', 'mdx'); ?></label></th>
-                    <td>
-                        <?php $mdx_v_post_list_2 = mdx_get_option('mdx_post_list_2'); ?>
-                        <select name="mdx_post_list_2" id="mdx_post_list_2">
-                            <option value="view" <?php if ($mdx_v_post_list_2 == 'view'){ ?>selected="selected"<?php } ?>><?php echo $mdx_i18n_settings_1; ?></option>
-                            <option value="time" <?php if ($mdx_v_post_list_2 == 'time'){ ?>selected="selected"<?php } ?>><?php echo $mdx_i18n_settings_2; ?></option>
-                            <option value="comments" <?php if ($mdx_v_post_list_2 == 'comments'){ ?>selected="selected"<?php } ?>><?php echo $mdx_i18n_settings_3; ?></option>
-                            <option value="blank" <?php if ($mdx_v_post_list_2 == 'blank'){ ?>selected="selected"<?php } ?>><?php echo $mdx_i18n_settings_4; ?></option>
-                        </select>
-                    </td>
-                </tr>
-                <tr>
-                    <th scope="row"><label for="mdx_post_list_3"><?php _e('文章列表详细信息 - 位置3', 'mdx'); ?></label></th>
-                    <td>
-                        <?php $mdx_v_post_list_3 = mdx_get_option('mdx_post_list_3'); ?>
-                        <select name="mdx_post_list_3" id="mdx_post_list_3">
-                            <option value="view" <?php if ($mdx_v_post_list_3 == 'view'){ ?>selected="selected"<?php } ?>><?php echo $mdx_i18n_settings_1; ?></option>
-                            <option value="time" <?php if ($mdx_v_post_list_3 == 'time'){ ?>selected="selected"<?php } ?>><?php echo $mdx_i18n_settings_2; ?></option>
-                            <option value="comments" <?php if ($mdx_v_post_list_3 == 'comments'){ ?>selected="selected"<?php } ?>><?php echo $mdx_i18n_settings_3; ?></option>
-                            <option value="blank" <?php if ($mdx_v_post_list_3 == 'blank'){ ?>selected="selected"<?php } ?>><?php echo $mdx_i18n_settings_4; ?></option>
-                        </select>
-                        <p class="description"><?php _e('详细信息显示在文章列表每篇文章的底部。在此指定你希望展示的信息。', 'mdx'); ?></p>
-                    </td>
-                </tr>
-                <tr>
-                    <th scope="row"><label for="mdx_enhanced_ajax"><?php _e('增强的文章列表加载方式', 'mdx'); ?></label></th>
-                    <td>
-                        <?php $mdx_v_enhanced_ajax = mdx_get_option('mdx_enhanced_ajax'); ?>
-                        <fieldset>
-                            <label><input type="radio" name="mdx_enhanced_ajax" value="true" <?php if ($mdx_v_enhanced_ajax == 'true'){ ?>checked="checked"<?php } ?>> <?php echo $trueon; ?>
-                            </label><br>
-                            <label><input type="radio" name="mdx_enhanced_ajax" value="false" <?php if ($mdx_v_enhanced_ajax == 'false'){ ?>checked="checked"<?php } ?>> <?php echo $falseoff; ?>
-                            </label><br>
-                            <p class="description"><?php _e('启用此选项以加快文章列表的加载速度，并使浏览器在后退到文章列表时尽可能地保持滚动位置。<br>受浏览器限制，在拥有大量文章时此功能效果可能会受限。', 'mdx'); ?></p>
-                        </fieldset>
-                    </td>
-                </tr>
-                <tr>
-                    <th scope="row"><?php _e('允许通过文章列表进入状态页', 'mdx'); ?></th>
-                    <td>
-                        <?php $mdx_v_click_status = mdx_get_option('mdx_click_status'); ?>
-                        <fieldset>
-                            <label><input type="radio" name="mdx_click_status" value="true" <?php if ($mdx_v_click_status == 'true'){ ?>checked="checked"<?php } ?>> <?php echo $trueon; ?>
-                            </label><br>
-                            <label><input type="radio" name="mdx_click_status" value="false" <?php if ($mdx_v_click_status == 'false'){ ?>checked="checked"<?php } ?>> <?php echo $falseoff; ?>
-                            </label><br>
-                            <p class="description"><?php _e('开启后，文章列表中的“状态”类型文章将会链接到对应文章页。', 'mdx'); ?></p>
-                        </fieldset>
-                    </td>
-                </tr>
+            <tr>
+                <th scope="row"><label for="mdx_readmore"><?php _e( '“阅读更多”文本自定义', 'mdx' ); ?></label></th>
+                <td><input name="mdx_readmore" type="text" id="mdx_readmore"
+                           value="<?php echo esc_attr( mdx_get_option( 'mdx_readmore' ) ) ?>" class="regular-text">
+                    <p class="description" id="mdx_footer"><?php _e( '在此自定义“阅读更多”按钮上的文本。', 'mdx' ); ?></p></td>
+            </tr>
+            <tr>
+                <th scope="row"><label for="mdx_post_list_click_area"><?php _e( '文章列表链接可点击区域', 'mdx' ); ?></label></th>
+                <td>
+					<?php $mdx_v_post_list_click_area = mdx_get_option( 'mdx_post_list_click_area' ); ?>
+                    <select name="mdx_post_list_click_area" id="mdx_post_list_click_area">
+                        <option value="title" <?php if ( $mdx_v_post_list_click_area == 'title' ){ ?>selected="selected"<?php } ?>><?php _e( "仅标题", "mdx" ); ?></option>
+                        <option value="pic" <?php if ( $mdx_v_post_list_click_area == 'pic' ){ ?>selected="selected"<?php } ?>><?php _e( "标题和文章特色图像", "mdx" ); ?></option>
+                    </select>
+                </td>
+            </tr>
+            <tr>
+                <th scope="row"><label for="mdx_post_list_1"><?php _e( '文章列表详细信息 - 位置1', 'mdx' ); ?></label></th>
+                <td>
+					<?php $mdx_v_post_list_1 = mdx_get_option( 'mdx_post_list_1' ); ?>
+					<?php
+					$mdx_i18n_settings_1 = __( '浏览量', 'mdx' );
+					$mdx_i18n_settings_2 = __( '发表时间', 'mdx' );
+					$mdx_i18n_settings_3 = __( '评论数', 'mdx' );
+					$mdx_i18n_settings_4 = __( '空', 'mdx' );
+					?>
+                    <select name="mdx_post_list_1" id="mdx_post_list_1">
+                        <option value="view" <?php if ( $mdx_v_post_list_1 == 'view' ){ ?>selected="selected"<?php } ?>><?php echo $mdx_i18n_settings_1; ?></option>
+                        <option value="time" <?php if ( $mdx_v_post_list_1 == 'time' ){ ?>selected="selected"<?php } ?>><?php echo $mdx_i18n_settings_2; ?></option>
+                        <option value="comments" <?php if ( $mdx_v_post_list_1 == 'comments' ){ ?>selected="selected"<?php } ?>><?php echo $mdx_i18n_settings_3; ?></option>
+                        <option value="blank" <?php if ( $mdx_v_post_list_1 == 'blank' ){ ?>selected="selected"<?php } ?>><?php echo $mdx_i18n_settings_4; ?></option>
+                    </select>
+                </td>
+            </tr>
+            <tr>
+                <th scope="row"><label for="mdx_post_list_2"><?php _e( '文章列表详细信息 - 位置2', 'mdx' ); ?></label></th>
+                <td>
+					<?php $mdx_v_post_list_2 = mdx_get_option( 'mdx_post_list_2' ); ?>
+                    <select name="mdx_post_list_2" id="mdx_post_list_2">
+                        <option value="view" <?php if ( $mdx_v_post_list_2 == 'view' ){ ?>selected="selected"<?php } ?>><?php echo $mdx_i18n_settings_1; ?></option>
+                        <option value="time" <?php if ( $mdx_v_post_list_2 == 'time' ){ ?>selected="selected"<?php } ?>><?php echo $mdx_i18n_settings_2; ?></option>
+                        <option value="comments" <?php if ( $mdx_v_post_list_2 == 'comments' ){ ?>selected="selected"<?php } ?>><?php echo $mdx_i18n_settings_3; ?></option>
+                        <option value="blank" <?php if ( $mdx_v_post_list_2 == 'blank' ){ ?>selected="selected"<?php } ?>><?php echo $mdx_i18n_settings_4; ?></option>
+                    </select>
+                </td>
+            </tr>
+            <tr>
+                <th scope="row"><label for="mdx_post_list_3"><?php _e( '文章列表详细信息 - 位置3', 'mdx' ); ?></label></th>
+                <td>
+					<?php $mdx_v_post_list_3 = mdx_get_option( 'mdx_post_list_3' ); ?>
+                    <select name="mdx_post_list_3" id="mdx_post_list_3">
+                        <option value="view" <?php if ( $mdx_v_post_list_3 == 'view' ){ ?>selected="selected"<?php } ?>><?php echo $mdx_i18n_settings_1; ?></option>
+                        <option value="time" <?php if ( $mdx_v_post_list_3 == 'time' ){ ?>selected="selected"<?php } ?>><?php echo $mdx_i18n_settings_2; ?></option>
+                        <option value="comments" <?php if ( $mdx_v_post_list_3 == 'comments' ){ ?>selected="selected"<?php } ?>><?php echo $mdx_i18n_settings_3; ?></option>
+                        <option value="blank" <?php if ( $mdx_v_post_list_3 == 'blank' ){ ?>selected="selected"<?php } ?>><?php echo $mdx_i18n_settings_4; ?></option>
+                    </select>
+                    <p class="description"><?php _e( '详细信息显示在文章列表每篇文章的底部。在此指定你希望展示的信息。', 'mdx' ); ?></p>
+                </td>
+            </tr>
+            <tr>
+                <th scope="row"><label for="mdx_enhanced_ajax"><?php _e( '增强的文章列表加载方式', 'mdx' ); ?></label></th>
+                <td>
+					<?php $mdx_v_enhanced_ajax = mdx_get_option( 'mdx_enhanced_ajax' ); ?>
+                    <fieldset>
+                        <label><input type="radio" name="mdx_enhanced_ajax" value="true" <?php if ( $mdx_v_enhanced_ajax == 'true' ){ ?>checked="checked"<?php } ?>> <?php echo $trueon; ?>
+                        </label><br>
+                        <label><input type="radio" name="mdx_enhanced_ajax" value="false" <?php if ( $mdx_v_enhanced_ajax == 'false' ){ ?>checked="checked"<?php } ?>> <?php echo $falseoff; ?>
+                        </label><br>
+                        <p class="description"><?php _e( '启用此选项以加快文章列表的加载速度，并使浏览器在后退到文章列表时尽可能地保持滚动位置。<br>受浏览器限制，在拥有大量文章时此功能效果可能会受限。', 'mdx' ); ?></p>
+                    </fieldset>
+                </td>
+            </tr>
+            <tr>
+                <th scope="row"><?php _e( '允许通过文章列表进入状态页', 'mdx' ); ?></th>
+                <td>
+					<?php $mdx_v_click_status = mdx_get_option( 'mdx_click_status' ); ?>
+                    <fieldset>
+                        <label><input type="radio" name="mdx_click_status" value="true" <?php if ( $mdx_v_click_status == 'true' ){ ?>checked="checked"<?php } ?>> <?php echo $trueon; ?>
+                        </label><br>
+                        <label><input type="radio" name="mdx_click_status" value="false" <?php if ( $mdx_v_click_status == 'false' ){ ?>checked="checked"<?php } ?>> <?php echo $falseoff; ?>
+                        </label><br>
+                        <p class="description"><?php _e( '开启后，文章列表中的“状态”类型文章将会链接到对应文章页。', 'mdx' ); ?></p>
+                    </fieldset>
+                </td>
+            </tr>
             </tbody>
 
             <tbody class="mdx-admin-section" id="mdx-admin-nav-toc-section">
-                <tr>
-                    <th scope="row"><?php _e('文章目录', 'mdx'); ?></th>
-                    <td>
-                        <?php $mdx_v_toc = mdx_get_option('mdx_toc'); ?>
-                        <fieldset>
-                            <label><input type="radio" name="mdx_toc" class="mdx_toc" value="true" <?php if ($mdx_v_toc == 'true'){ ?>checked="checked"<?php } ?>> <?php echo $trueon; ?>
-                            </label><br>
-                            <label><input type="radio" name="mdx_toc" class="mdx_toc" value="false" <?php if ($mdx_v_toc == 'false'){ ?>checked="checked"<?php } ?>> <?php echo $falseoff; ?>
-                            </label><br>
-                            <p class="description"><?php _e('开启后，侧边栏会显示文章目录。', 'mdx'); ?></p>
-                        </fieldset>
-                    </td>
-                </tr>
-                <tr>
-                    <th scope="row"><?php _e('文章目录缩略显示', 'mdx'); ?></th>
-                    <td>
-                        <?php $mdx_v_toc_preview = mdx_get_option('mdx_toc_preview'); ?>
-                        <fieldset>
-                            <label><input type="radio" name="mdx_toc_preview" class="mdx_toc_preview" value="true" <?php if ($mdx_v_toc_preview == 'true'){ ?>checked="checked"<?php } ?>> <?php echo $trueon; ?>
-                            </label><br>
-                            <label><input type="radio" name="mdx_toc_preview" class="mdx_toc_preview" value="false" <?php if ($mdx_v_toc_preview == 'false'){ ?>checked="checked"<?php } ?>> <?php echo $falseoff; ?>
-                            </label><br>
-                            <p class="description"><?php _e('开启后，桌面端文章左侧会显示简略目录，点击即可打开完整目录。', 'mdx'); ?></p>
-                        </fieldset>
-                    </td>
-                </tr>
+            <tr>
+                <th scope="row"><?php _e( '文章目录', 'mdx' ); ?></th>
+                <td>
+					<?php $mdx_v_toc = mdx_get_option( 'mdx_toc' ); ?>
+                    <fieldset>
+                        <label><input type="radio" name="mdx_toc" class="mdx_toc" value="true" <?php if ( $mdx_v_toc == 'true' ){ ?>checked="checked"<?php } ?>> <?php echo $trueon; ?>
+                        </label><br>
+                        <label><input type="radio" name="mdx_toc" class="mdx_toc" value="false" <?php if ( $mdx_v_toc == 'false' ){ ?>checked="checked"<?php } ?>> <?php echo $falseoff; ?>
+                        </label><br>
+                        <p class="description"><?php _e( '开启后，侧边栏会显示文章目录。', 'mdx' ); ?></p>
+                    </fieldset>
+                </td>
+            </tr>
+            <tr>
+                <th scope="row"><?php _e( '文章目录缩略显示', 'mdx' ); ?></th>
+                <td>
+					<?php $mdx_v_toc_preview = mdx_get_option( 'mdx_toc_preview' ); ?>
+                    <fieldset>
+                        <label><input type="radio" name="mdx_toc_preview" class="mdx_toc_preview" value="true" <?php if ( $mdx_v_toc_preview == 'true' ){ ?>checked="checked"<?php } ?>> <?php echo $trueon; ?>
+                        </label><br>
+                        <label><input type="radio" name="mdx_toc_preview" class="mdx_toc_preview" value="false" <?php if ( $mdx_v_toc_preview == 'false' ){ ?>checked="checked"<?php } ?>> <?php echo $falseoff; ?>
+                        </label><br>
+                        <p class="description"><?php _e( '开启后，桌面端文章左侧会显示简略目录，点击即可打开完整目录。', 'mdx' ); ?></p>
+                    </fieldset>
+                </td>
+            </tr>
             </tbody>
 
             <tbody class="mdx-admin-section" id="mdx-admin-nav-suggestion-section">
-                <tr>
-                    <th scope="row"><?php _e('首页推荐文章', 'mdx'); ?></th>
-                    <td>
-                        <?php $mdx_v_hot_posts = mdx_get_option('mdx_hot_posts'); ?>
-                        <fieldset>
-                            <label><input type="radio" class="mdx_apsp2" name="mdx_hot_posts" value="true" <?php if ($mdx_v_hot_posts == 'true'){ ?>checked="checked"<?php } ?>> <?php echo $trueon; ?>
-                            </label><br>
-                            <label><input type="radio" class="mdx_apsp2" name="mdx_hot_posts" value="false" <?php if ($mdx_v_hot_posts == 'false'){ ?>checked="checked"<?php } ?>> <?php echo $falseoff; ?>
-                            </label><br>
-                            <p class="description"><?php _e('开启后，首页会展示推荐文章，请在下方进行设置。', 'mdx'); ?></p>
-                        </fieldset>
-                    </td>
-                </tr>
-                <tr>
-                    <th scope="row"><label for="mdx_hot_posts_num"><?php _e('首页推荐文章数量', 'mdx'); ?></label></th>
-                    <td><input name="mdx_hot_posts_num" type="number" id="mdx_hot_posts_num" min="1"
-                            value="<?php echo esc_attr(mdx_get_option('mdx_hot_posts_num')) ?>"
-                            class="regular-text mdx_apspc2">
-                        <p class="description"><?php _e('在此设定首页推荐文章篇数。请输入大于 0 的整数。', 'mdx'); ?></p></td>
-                </tr>
-                <tr>
-                    <th scope="row"><?php _e('首页推荐文章获取方式', 'mdx'); ?></th>
-                    <td>
-                        <?php $mdx_v_hot_posts_get = mdx_get_option('mdx_hot_posts_get'); ?>
-                        <fieldset>
-                            <label><input type="radio" class="mdx_get mdx_apspc2" name="mdx_hot_posts_get" value="cat" <?php if ($mdx_v_hot_posts_get == 'cat'){ ?>checked="checked"<?php } ?>> <?php _e('某一分类', 'mdx'); ?>
-                            </label><br>
-                            <label><input type="radio" class="mdx_get mdx_apspc2" name="mdx_hot_posts_get" value="sticky" <?php if ($mdx_v_hot_posts_get == 'sticky'){ ?>checked="checked"<?php } ?>> <?php _e('置顶文章', 'mdx'); ?>
-                            </label><br>
-                            <p class="description"><?php _e('在此设定首页推荐文章的获取方式。<br>若选择置顶文章，当没有置顶文章时，首页推荐文章模块将不会显示，同时文章列表将保持原始顺序而不会被置顶文章打乱。', 'mdx'); ?></p>
-                        </fieldset>
-                    </td>
-                </tr>
-                <tr>
-                    <th scope="row"><label for="mdx_hot_posts_cat"><?php _e('首页推荐文章分类名', 'mdx'); ?></label></th>
-                    <td><input name="mdx_hot_posts_cat" type="text" id="mdx_hot_posts_cat"
-                            value="<?php echo esc_attr(mdx_get_option('mdx_hot_posts_cat')) ?>"
-                            class="regular-text mdx_apspc2">
-                        <p class="description"><?php _e('在此设定首页推荐文章的分类名。当分类不存在时，将显示最新文章。', 'mdx'); ?></p></td>
-                </tr>
-                <tr>
-                    <th scope="row"><label for="mdx_hot_posts_text"><?php _e('首页推荐文章模块标题', 'mdx'); ?></label></th>
-                    <td><input name="mdx_hot_posts_text" type="text" id="mdx_hot_posts_text"
-                            value="<?php echo esc_attr(mdx_get_option('mdx_hot_posts_text')) ?>"
-                            class="regular-text mdx_apspc2">
-                        <p class="description"><?php _e('在此设定首页推荐文章模块标题。', 'mdx'); ?></p></td>
-                </tr>
-                <tr>
-                    <th scope="row"><label for="mdx_all_posts_text"><?php _e('首页最新文章模块标题', 'mdx'); ?></label></th>
-                    <td><input name="mdx_all_posts_text" type="text" id="mdx_all_posts_text"
-                            value="<?php echo esc_attr(mdx_get_option('mdx_all_posts_text')) ?>"
-                            class="regular-text mdx_apspc2">
-                        <p class="description"><?php _e('在此设定首页最新文章模块标题。只有开启了“首页推荐文章”功能时此空才会生效。', 'mdx'); ?></p></td>
-                </tr>
-                <tr>
-                    <td></td>
-                </tr>
-                <tr>
-                    <th scope="row"><?php _e('文末推荐文章', 'mdx'); ?></th>
-                    <td>
-                        <?php $mdx_v_you_may_like = mdx_get_option('mdx_you_may_like'); ?>
-                        <fieldset>
-                            <label><input type="radio" class="mdx_apsp" name="mdx_you_may_like" value="true" <?php if ($mdx_v_you_may_like == 'true'){ ?>checked="checked"<?php } ?>> <?php echo $trueon; ?>
-                            </label><br>
-                            <label><input type="radio" class="mdx_apsp" name="mdx_you_may_like" value="false" <?php if ($mdx_v_you_may_like == 'false'){ ?>checked="checked"<?php } ?>> <?php echo $falseoff; ?>
-                            </label><br>
-                            <p class="description"><?php _e('开启后，文章末会展示最多5篇相似文章。', 'mdx'); ?></p>
-                        </fieldset>
-                    </td>
-                </tr>
-                <tr>
-                    <th scope="row"><label for="mdx_you_may_like_num"><?php _e('文末推荐文章数量', 'mdx'); ?></label></th>
-                    <td><input name="mdx_you_may_like_num" type="number" id="mdx_you_may_like_num" min="1"
-                            value="<?php echo esc_attr(mdx_get_option('mdx_you_may_like_num')) ?>"
-                            class="regular-text mdx_apspc">
-                        <p class="description"><?php _e('在此文末首页推荐文章篇数。请输入大于 0 的整数。', 'mdx'); ?></p></td>
-                </tr>
-                <tr>
-                    <th scope="row"><?php _e('文末推荐文章计算方式', 'mdx'); ?></th>
-                    <td>
-                        <?php $mdx_v_you_may_like_way = mdx_get_option('mdx_you_may_like_way'); ?>
-                        <fieldset>
-                            <label><input type="radio" class="mdx_apspc" name="mdx_you_may_like_way" value="tag" <?php if ($mdx_v_you_may_like_way == 'tag'){ ?>checked="checked"<?php } ?>> <?php _e('相同标签', 'mdx') ?>
-                            </label><br>
-                            <label><input type="radio" class="mdx_apspc" name="mdx_you_may_like_way" value="category" <?php if ($mdx_v_you_may_like_way == 'category'){ ?>checked="checked"<?php } ?>> <?php _e('相同分类', 'mdx') ?>
-                            </label><br>
-                        </fieldset>
-                    </td>
-                </tr>
-                <tr>
-                    <th scope="row"><label for="mdx_you_may_like_text"><?php _e('文末推荐文章模块标题', 'mdx'); ?></label></th>
-                    <td><input name="mdx_you_may_like_text" type="text" id="mdx_you_may_like_text"
-                            value="<?php echo esc_attr(mdx_get_option('mdx_you_may_like_text')) ?>"
-                            class="regular-text mdx_apspc">
-                </tr>
+            <tr>
+                <th scope="row"><?php _e( '首页推荐文章', 'mdx' ); ?></th>
+                <td>
+					<?php $mdx_v_hot_posts = mdx_get_option( 'mdx_hot_posts' ); ?>
+                    <fieldset>
+                        <label><input type="radio" class="mdx_apsp2" name="mdx_hot_posts" value="true" <?php if ( $mdx_v_hot_posts == 'true' ){ ?>checked="checked"<?php } ?>> <?php echo $trueon; ?>
+                        </label><br>
+                        <label><input type="radio" class="mdx_apsp2" name="mdx_hot_posts" value="false" <?php if ( $mdx_v_hot_posts == 'false' ){ ?>checked="checked"<?php } ?>> <?php echo $falseoff; ?>
+                        </label><br>
+                        <p class="description"><?php _e( '开启后，首页会展示推荐文章，请在下方进行设置。', 'mdx' ); ?></p>
+                    </fieldset>
+                </td>
+            </tr>
+            <tr>
+                <th scope="row"><label for="mdx_hot_posts_num"><?php _e( '首页推荐文章数量', 'mdx' ); ?></label></th>
+                <td><input name="mdx_hot_posts_num" type="number" id="mdx_hot_posts_num" min="1"
+                           value="<?php echo esc_attr( mdx_get_option( 'mdx_hot_posts_num' ) ) ?>"
+                           class="regular-text mdx_apspc2">
+                    <p class="description"><?php _e( '在此设定首页推荐文章篇数。请输入大于 0 的整数。', 'mdx' ); ?></p></td>
+            </tr>
+            <tr>
+                <th scope="row"><?php _e( '首页推荐文章获取方式', 'mdx' ); ?></th>
+                <td>
+					<?php $mdx_v_hot_posts_get = mdx_get_option( 'mdx_hot_posts_get' ); ?>
+                    <fieldset>
+                        <label><input type="radio" class="mdx_get mdx_apspc2" name="mdx_hot_posts_get" value="cat" <?php if ( $mdx_v_hot_posts_get == 'cat' ){ ?>checked="checked"<?php } ?>> <?php _e( '某一分类', 'mdx' ); ?>
+                        </label><br>
+                        <label><input type="radio" class="mdx_get mdx_apspc2" name="mdx_hot_posts_get" value="sticky" <?php if ( $mdx_v_hot_posts_get == 'sticky' ){ ?>checked="checked"<?php } ?>> <?php _e( '置顶文章', 'mdx' ); ?>
+                        </label><br>
+                        <p class="description"><?php _e( '在此设定首页推荐文章的获取方式。<br>若选择置顶文章，当没有置顶文章时，首页推荐文章模块将不会显示，同时文章列表将保持原始顺序而不会被置顶文章打乱。', 'mdx' ); ?></p>
+                    </fieldset>
+                </td>
+            </tr>
+            <tr>
+                <th scope="row"><label for="mdx_hot_posts_cat"><?php _e( '首页推荐文章分类名', 'mdx' ); ?></label></th>
+                <td><input name="mdx_hot_posts_cat" type="text" id="mdx_hot_posts_cat"
+                           value="<?php echo esc_attr( mdx_get_option( 'mdx_hot_posts_cat' ) ) ?>"
+                           class="regular-text mdx_apspc2">
+                    <p class="description"><?php _e( '在此设定首页推荐文章的分类名。当分类不存在时，将显示最新文章。', 'mdx' ); ?></p></td>
+            </tr>
+            <tr>
+                <th scope="row"><label for="mdx_hot_posts_text"><?php _e( '首页推荐文章模块标题', 'mdx' ); ?></label></th>
+                <td><input name="mdx_hot_posts_text" type="text" id="mdx_hot_posts_text"
+                           value="<?php echo esc_attr( mdx_get_option( 'mdx_hot_posts_text' ) ) ?>"
+                           class="regular-text mdx_apspc2">
+                    <p class="description"><?php _e( '在此设定首页推荐文章模块标题。', 'mdx' ); ?></p></td>
+            </tr>
+            <tr>
+                <th scope="row"><label for="mdx_all_posts_text"><?php _e( '首页最新文章模块标题', 'mdx' ); ?></label></th>
+                <td><input name="mdx_all_posts_text" type="text" id="mdx_all_posts_text"
+                           value="<?php echo esc_attr( mdx_get_option( 'mdx_all_posts_text' ) ) ?>"
+                           class="regular-text mdx_apspc2">
+                    <p class="description"><?php _e( '在此设定首页最新文章模块标题。只有开启了“首页推荐文章”功能时此空才会生效。', 'mdx' ); ?></p></td>
+            </tr>
+            <tr>
+                <td></td>
+            </tr>
+            <tr>
+                <th scope="row"><?php _e( '文末推荐文章', 'mdx' ); ?></th>
+                <td>
+					<?php $mdx_v_you_may_like = mdx_get_option( 'mdx_you_may_like' ); ?>
+                    <fieldset>
+                        <label><input type="radio" class="mdx_apsp" name="mdx_you_may_like" value="true" <?php if ( $mdx_v_you_may_like == 'true' ){ ?>checked="checked"<?php } ?>> <?php echo $trueon; ?>
+                        </label><br>
+                        <label><input type="radio" class="mdx_apsp" name="mdx_you_may_like" value="false" <?php if ( $mdx_v_you_may_like == 'false' ){ ?>checked="checked"<?php } ?>> <?php echo $falseoff; ?>
+                        </label><br>
+                        <p class="description"><?php _e( '开启后，文章末会展示最多5篇相似文章。', 'mdx' ); ?></p>
+                    </fieldset>
+                </td>
+            </tr>
+            <tr>
+                <th scope="row"><label for="mdx_you_may_like_num"><?php _e( '文末推荐文章数量', 'mdx' ); ?></label></th>
+                <td><input name="mdx_you_may_like_num" type="number" id="mdx_you_may_like_num" min="1"
+                           value="<?php echo esc_attr( mdx_get_option( 'mdx_you_may_like_num' ) ) ?>"
+                           class="regular-text mdx_apspc">
+                    <p class="description"><?php _e( '在此文末首页推荐文章篇数。请输入大于 0 的整数。', 'mdx' ); ?></p></td>
+            </tr>
+            <tr>
+                <th scope="row"><?php _e( '文末推荐文章计算方式', 'mdx' ); ?></th>
+                <td>
+					<?php $mdx_v_you_may_like_way = mdx_get_option( 'mdx_you_may_like_way' ); ?>
+                    <fieldset>
+                        <label><input type="radio" class="mdx_apspc" name="mdx_you_may_like_way" value="tag" <?php if ( $mdx_v_you_may_like_way == 'tag' ){ ?>checked="checked"<?php } ?>> <?php _e( '相同标签', 'mdx' ) ?>
+                        </label><br>
+                        <label><input type="radio" class="mdx_apspc" name="mdx_you_may_like_way" value="category" <?php if ( $mdx_v_you_may_like_way == 'category' ){ ?>checked="checked"<?php } ?>> <?php _e( '相同分类', 'mdx' ) ?>
+                        </label><br>
+                    </fieldset>
+                </td>
+            </tr>
+            <tr>
+                <th scope="row"><label for="mdx_you_may_like_text"><?php _e( '文末推荐文章模块标题', 'mdx' ); ?></label></th>
+                <td><input name="mdx_you_may_like_text" type="text" id="mdx_you_may_like_text"
+                           value="<?php echo esc_attr( mdx_get_option( 'mdx_you_may_like_text' ) ) ?>"
+                           class="regular-text mdx_apspc">
+            </tr>
             </tbody>
 
             <tbody class="mdx-admin-section" id="mdx-admin-nav-comment-section">
-                <tr>
-                    <th scope="row"><label for="mdx_submit_comment"><?php _e('“发送评论”文本自定义', 'mdx'); ?></label></th>
-                    <td><input name="mdx_submit_comment" type="text" id="mdx_submit_comment"
-                            value="<?php echo esc_attr(mdx_get_option('mdx_submit_comment')) ?>" class="regular-text">
-                        <p class="description"><?php _e('在此自定义“发送评论”按钮上的文本。', 'mdx'); ?></p></td>
-                </tr>
-                <tr>
-                    <th scope="row"><?php _e('评论无限加载', 'mdx'); ?></th>
-                    <td>
-                        <?php $mdx_v_comment_ajax = mdx_get_option('mdx_comment_ajax'); ?>
-                        <fieldset>
-                            <label><input type="radio" name="mdx_comment_ajax" value="true" <?php if ($mdx_v_comment_ajax == 'true'){ ?>checked="checked"<?php } ?>> <?php echo $trueon; ?>
-                            </label><br>
-                            <label><input type="radio" name="mdx_comment_ajax" value="false" <?php if ($mdx_v_comment_ajax == 'false'){ ?>checked="checked"<?php } ?>> <?php echo $falseoff; ?>
-                            </label><br>
-                            <p class="description"><?php _e('开启后，文章评论加载时将使用无限加载，关闭则使用分页加载。无论如何，评论均为 AJAX 加载。', 'mdx'); ?></p>
-                        </fieldset>
-                    </td>
-                </tr>
-                <tr>
-                    <th scope="row"><?php _e('评论表情', 'mdx'); ?></th>
-                    <td>
-                        <?php $mdx_v_comment_emj = mdx_get_option('mdx_comment_emj'); ?>
-                        <fieldset>
-                            <label><input type="radio" name="mdx_comment_emj" value="true" <?php if ($mdx_v_comment_emj == 'true'){ ?>checked="checked"<?php } ?>> <?php echo $trueon; ?>
-                            </label><br>
-                            <label><input type="radio" name="mdx_comment_emj" value="false" <?php if ($mdx_v_comment_emj == 'false'){ ?>checked="checked"<?php } ?>> <?php echo $falseoff; ?>
-                            </label><br>
-                            <p class="description"><?php _e('开启后，评论时可输入表情。开启后仍需安装表情插件才可正常使用。目前仅支持来自 mayuko 的 Alu 表情插件，请前往 <a href="https://doc.flyhigher.top/mdx/zh-CN/config/emoji-in-comment/" target="_blank">MDx 文档</a> 下载插件安装包。', 'mdx'); ?></p>
-                        </fieldset>
-                    </td>
-                </tr>
+            <tr>
+                <th scope="row"><label for="mdx_submit_comment"><?php _e( '“发送评论”文本自定义', 'mdx' ); ?></label></th>
+                <td><input name="mdx_submit_comment" type="text" id="mdx_submit_comment"
+                           value="<?php echo esc_attr( mdx_get_option( 'mdx_submit_comment' ) ) ?>" class="regular-text">
+                    <p class="description"><?php _e( '在此自定义“发送评论”按钮上的文本。', 'mdx' ); ?></p></td>
+            </tr>
+            <tr>
+                <th scope="row"><?php _e( '评论无限加载', 'mdx' ); ?></th>
+                <td>
+					<?php $mdx_v_comment_ajax = mdx_get_option( 'mdx_comment_ajax' ); ?>
+                    <fieldset>
+                        <label><input type="radio" name="mdx_comment_ajax" value="true" <?php if ( $mdx_v_comment_ajax == 'true' ){ ?>checked="checked"<?php } ?>> <?php echo $trueon; ?>
+                        </label><br>
+                        <label><input type="radio" name="mdx_comment_ajax" value="false" <?php if ( $mdx_v_comment_ajax == 'false' ){ ?>checked="checked"<?php } ?>> <?php echo $falseoff; ?>
+                        </label><br>
+                        <p class="description"><?php _e( '开启后，文章评论加载时将使用无限加载，关闭则使用分页加载。无论如何，评论均为 AJAX 加载。', 'mdx' ); ?></p>
+                    </fieldset>
+                </td>
+            </tr>
+            <tr>
+                <th scope="row"><?php _e( '评论表情', 'mdx' ); ?></th>
+                <td>
+					<?php $mdx_v_comment_emj = mdx_get_option( 'mdx_comment_emj' ); ?>
+                    <fieldset>
+                        <label><input type="radio" name="mdx_comment_emj" value="true" <?php if ( $mdx_v_comment_emj == 'true' ){ ?>checked="checked"<?php } ?>> <?php echo $trueon; ?>
+                        </label><br>
+                        <label><input type="radio" name="mdx_comment_emj" value="false" <?php if ( $mdx_v_comment_emj == 'false' ){ ?>checked="checked"<?php } ?>> <?php echo $falseoff; ?>
+                        </label><br>
+                        <p class="description"><?php _e( '开启后，评论时可输入表情。开启后仍需安装表情插件才可正常使用。目前仅支持来自 mayuko 的 Alu 表情插件，请前往 <a href="https://doc.flyhigher.top/mdx/zh-CN/config/emoji-in-comment/" target="_blank">MDx 文档</a> 下载插件安装包。', 'mdx' ); ?></p>
+                    </fieldset>
+                </td>
+            </tr>
             </tbody>
 
             <tbody class="mdx-admin-section" id="mdx-admin-nav-lazyload-section">
-                <tr>
-                    <th scope="row"><label for="mdx_lazy_load_mode"><?php _e('LazyLoad 模式', 'mdx'); ?></label></th>
-                    <td>
-                        <?php $mdx_v_lazy_load_mode = mdx_get_option('mdx_lazy_load_mode'); ?>
-                        <select name="mdx_lazy_load_mode" id="mdx_lazy_load_mode">
-                            <option value="speed" <?php if ($mdx_v_lazy_load_mode == 'speed'){ ?>selected="selected"<?php } ?>><?php _e('速度优先', 'mdx'); ?></option>
-                            <option value="seo1" <?php if ($mdx_v_lazy_load_mode == 'seo1'){ ?>selected="selected"<?php } ?>><?php _e('SEO优先（轻度）', 'mdx'); ?></option>
-                            <option value="seo2" <?php if ($mdx_v_lazy_load_mode == 'seo2'){ ?>selected="selected"<?php } ?>><?php _e('SEO优先（重度）', 'mdx'); ?></option>
-                        </select>
-                        <p class="description"><?php _e('LazyLoad 即图片会在即将滚动到屏幕内时才开始加载的技术（可能会影响 SEO）。此设置会影响图片加载模式。</p><ul><li><code>速度优先</code>：几乎所有图片都会使用 LazyLoad</li><li><code>SEO优先（轻度）</code>：除文章内使用的图片外几乎所有图片都会使用 LazyLoad</li><li><code>SEO优先（重度）</code>：文章内使用的图片和文章列表使用的图片不会使用 LazyLoad，但仍有少量装饰性图片会使用</li></ul>', 'mdx'); ?>
-                    </td>
-                </tr>
-                <tr>
-                    <th scope="row"><label for="mdx_lazyload_fallback"><?php _e('兼容性 Lazyload', 'mdx'); ?></label></th>
-                    <td>
-                        <?php $mdx_v_lazyload_fallback = mdx_get_option('mdx_lazyload_fallback'); ?>
-                        <fieldset>
-                            <label><input type="radio" name="mdx_lazyload_fallback" value="true" <?php if ($mdx_v_lazyload_fallback == 'true'){ ?>checked="checked"<?php } ?>> <?php echo $trueon; ?>
-                            </label><br>
-                            <label><input type="radio" name="mdx_lazyload_fallback" value="false" <?php if ($mdx_v_lazyload_fallback == 'false'){ ?>checked="checked"<?php } ?>> <?php echo $falseoff; ?>
-                            </label><br>
-                            <p class="description"><?php _e('尝试以兼容性更好的方式加载图片，<strong>但会导致一些增强特性不可用。</strong><br>如果你发现文章内图片的 Lazyload 加载出现问题且希望保留文章内图片的 Lazyload，可以尝试打开此选项。', 'mdx'); ?></p>
-                        </fieldset>
-                    </td>
-                </tr>
+            <tr>
+                <th scope="row"><label for="mdx_lazy_load_mode"><?php _e( 'LazyLoad 模式', 'mdx' ); ?></label></th>
+                <td>
+					<?php $mdx_v_lazy_load_mode = mdx_get_option( 'mdx_lazy_load_mode' ); ?>
+                    <select name="mdx_lazy_load_mode" id="mdx_lazy_load_mode">
+                        <option value="speed" <?php if ( $mdx_v_lazy_load_mode == 'speed' ){ ?>selected="selected"<?php } ?>><?php _e( '速度优先', 'mdx' ); ?></option>
+                        <option value="seo1" <?php if ( $mdx_v_lazy_load_mode == 'seo1' ){ ?>selected="selected"<?php } ?>><?php _e( 'SEO优先（轻度）', 'mdx' ); ?></option>
+                        <option value="seo2" <?php if ( $mdx_v_lazy_load_mode == 'seo2' ){ ?>selected="selected"<?php } ?>><?php _e( 'SEO优先（重度）', 'mdx' ); ?></option>
+                    </select>
+                    <p class="description"><?php _e( 'LazyLoad 即图片会在即将滚动到屏幕内时才开始加载的技术（可能会影响 SEO）。此设置会影响图片加载模式。</p><ul><li><code>速度优先</code>：几乎所有图片都会使用 LazyLoad</li><li><code>SEO优先（轻度）</code>：除文章内使用的图片外几乎所有图片都会使用 LazyLoad</li><li><code>SEO优先（重度）</code>：文章内使用的图片和文章列表使用的图片不会使用 LazyLoad，但仍有少量装饰性图片会使用</li></ul>', 'mdx' ); ?>
+                </td>
+            </tr>
+            <tr>
+                <th scope="row"><label for="mdx_lazyload_fallback"><?php _e( '兼容性 Lazyload', 'mdx' ); ?></label></th>
+                <td>
+					<?php $mdx_v_lazyload_fallback = mdx_get_option( 'mdx_lazyload_fallback' ); ?>
+                    <fieldset>
+                        <label><input type="radio" name="mdx_lazyload_fallback" value="true" <?php if ( $mdx_v_lazyload_fallback == 'true' ){ ?>checked="checked"<?php } ?>> <?php echo $trueon; ?>
+                        </label><br>
+                        <label><input type="radio" name="mdx_lazyload_fallback" value="false" <?php if ( $mdx_v_lazyload_fallback == 'false' ){ ?>checked="checked"<?php } ?>> <?php echo $falseoff; ?>
+                        </label><br>
+                        <p class="description"><?php _e( '尝试以兼容性更好的方式加载图片，<strong>但会导致一些增强特性不可用。</strong><br>如果你发现文章内图片的 Lazyload 加载出现问题且希望保留文章内图片的 Lazyload，可以尝试打开此选项。', 'mdx' ); ?></p>
+                    </fieldset>
+                </td>
+            </tr>
             </tbody>
 
             <tbody class="mdx-admin-section" id="mdx-admin-nav-accessibility-section">
-                <tr>
-                    <th scope="row"><?php _e('允许用户缩放页面', 'mdx'); ?></th>
-                    <td>
-                        <?php $mdx_v_allow_scale = mdx_get_option('mdx_allow_scale'); ?>
-                        <fieldset>
-                            <label><input type="radio" name="mdx_allow_scale" value="true" <?php if ($mdx_v_allow_scale == 'true'){ ?>checked="checked"<?php } ?>> <?php echo $trueon; ?>
-                            </label><br>
-                            <label><input type="radio" name="mdx_allow_scale" value="false" <?php if ($mdx_v_allow_scale == 'false'){ ?>checked="checked"<?php } ?>> <?php echo $falseoff; ?>
-                            </label><br>
-                            <p class="description"><?php _e('如果允许用户缩放页面，用户将可以放大页面。这可能会破坏页面结构，但有助于视力障碍用户更好地阅读。关闭即可将页面的缩放强制固定在默认倍率。注意，不同浏览器对此可能会有不同的表现。', 'mdx'); ?></p>
-                        </fieldset>
-                    </td>
-                </tr>
-                <tr>
-                    <th scope="row"><?php _e('允许使用减弱动画模式', 'mdx'); ?></th>
-                    <td>
-                        <?php $mdx_v_reduce_motion = mdx_get_option('mdx_reduce_motion'); ?>
-                        <fieldset>
-                            <label><input type="radio" name="mdx_reduce_motion" value="true" <?php if ($mdx_v_reduce_motion == 'true'){ ?>checked="checked"<?php } ?>> <?php echo $trueon; ?>
-                            </label><br>
-                            <label><input type="radio" name="mdx_reduce_motion" value="false" <?php if ($mdx_v_reduce_motion == 'false'){ ?>checked="checked"<?php } ?>> <?php echo $falseoff; ?>
-                            </label><br>
-                            <p class="description"><?php _e('开启后，如果用户的系统开启了减弱动画模式，MDx 会自动地尽可能减弱网页内的动画。', 'mdx'); ?></p>
-                        </fieldset>
-                    </td>
-                </tr>
+            <tr>
+                <th scope="row"><?php _e( '允许用户缩放页面', 'mdx' ); ?></th>
+                <td>
+					<?php $mdx_v_allow_scale = mdx_get_option( 'mdx_allow_scale' ); ?>
+                    <fieldset>
+                        <label><input type="radio" name="mdx_allow_scale" value="true" <?php if ( $mdx_v_allow_scale == 'true' ){ ?>checked="checked"<?php } ?>> <?php echo $trueon; ?>
+                        </label><br>
+                        <label><input type="radio" name="mdx_allow_scale" value="false" <?php if ( $mdx_v_allow_scale == 'false' ){ ?>checked="checked"<?php } ?>> <?php echo $falseoff; ?>
+                        </label><br>
+                        <p class="description"><?php _e( '如果允许用户缩放页面，用户将可以放大页面。这可能会破坏页面结构，但有助于视力障碍用户更好地阅读。关闭即可将页面的缩放强制固定在默认倍率。注意，不同浏览器对此可能会有不同的表现。', 'mdx' ); ?></p>
+                    </fieldset>
+                </td>
+            </tr>
+            <tr>
+                <th scope="row"><?php _e( '允许使用减弱动画模式', 'mdx' ); ?></th>
+                <td>
+					<?php $mdx_v_reduce_motion = mdx_get_option( 'mdx_reduce_motion' ); ?>
+                    <fieldset>
+                        <label><input type="radio" name="mdx_reduce_motion" value="true" <?php if ( $mdx_v_reduce_motion == 'true' ){ ?>checked="checked"<?php } ?>> <?php echo $trueon; ?>
+                        </label><br>
+                        <label><input type="radio" name="mdx_reduce_motion" value="false" <?php if ( $mdx_v_reduce_motion == 'false' ){ ?>checked="checked"<?php } ?>> <?php echo $falseoff; ?>
+                        </label><br>
+                        <p class="description"><?php _e( '开启后，如果用户的系统开启了减弱动画模式，MDx 会自动地尽可能减弱网页内的动画。', 'mdx' ); ?></p>
+                    </fieldset>
+                </td>
+            </tr>
             </tbody>
 
             <tbody class="mdx-admin-section" id="mdx-admin-nav-ad-section">
-                <tr>
-                    <th scope="row"><label for="mdx_ad"><?php _e('广告代码', 'mdx'); ?></label></th>
-                    <td><textarea name="mdx_ad" id="mdx_ad" rows="7"
-                                cols="50"><?php echo mdx_get_option('mdx_ad') ?></textarea>
-                        <p class="description"><?php _e('在这里填写广告代码，MDx 会自行决定广告应出现在何处。此空留空则不会显示广告。<br>如果要在文章内插入广告，在这里填写广告代码后，你可以在文章中使用 <code>[mdx_ad][/mdx_ad]</code> 短代码。<br>如果你计划使用 Google AdSense 自动广告，请将其填写在“脚本 - 页头脚本”选项处。', 'mdx'); ?></p>
-                    </td>
-                </tr>
-                <tr>
-                    <th scope="row"><?php _e('对已登录的用户禁用广告', 'mdx'); ?></th>
-                    <td>
-                        <?php $mdx_v_logged_in_ad = mdx_get_option('mdx_logged_in_ad'); ?>
-                        <fieldset>
-                            <label><input type="radio" name="mdx_logged_in_ad" value="true" <?php if ($mdx_v_logged_in_ad == 'true'){ ?>checked="checked"<?php } ?>> <?php _e('禁用广告', 'mdx'); ?>
-                            </label><br>
-                            <label><input type="radio" name="mdx_logged_in_ad" value="false" <?php if ($mdx_v_logged_in_ad == 'false'){ ?>checked="checked"<?php } ?>> <?php _e('不禁用广告', 'mdx'); ?>
-                            </label><br>
-                        </fieldset>
-                    </td>
-                </tr>
+            <tr>
+                <th scope="row"><label for="mdx_ad"><?php _e( '广告代码', 'mdx' ); ?></label></th>
+                <td><textarea name="mdx_ad" id="mdx_ad" rows="7"
+                              cols="50"><?php echo mdx_get_option( 'mdx_ad' ) ?></textarea>
+                    <p class="description"><?php _e( '在这里填写广告代码，MDx 会自行决定广告应出现在何处。此空留空则不会显示广告。<br>如果要在文章内插入广告，在这里填写广告代码后，你可以在文章中使用 <code>[mdx_ad][/mdx_ad]</code> 短代码。<br>如果你计划使用 Google AdSense 自动广告，请将其填写在“脚本 - 页头脚本”选项处。', 'mdx' ); ?></p>
+                </td>
+            </tr>
+            <tr>
+                <th scope="row"><?php _e( '对已登录的用户禁用广告', 'mdx' ); ?></th>
+                <td>
+					<?php $mdx_v_logged_in_ad = mdx_get_option( 'mdx_logged_in_ad' ); ?>
+                    <fieldset>
+                        <label><input type="radio" name="mdx_logged_in_ad" value="true" <?php if ( $mdx_v_logged_in_ad == 'true' ){ ?>checked="checked"<?php } ?>> <?php _e( '禁用广告', 'mdx' ); ?>
+                        </label><br>
+                        <label><input type="radio" name="mdx_logged_in_ad" value="false" <?php if ( $mdx_v_logged_in_ad == 'false' ){ ?>checked="checked"<?php } ?>> <?php _e( '不禁用广告', 'mdx' ); ?>
+                        </label><br>
+                    </fieldset>
+                </td>
+            </tr>
             </tbody>
 
             <tbody class="mdx-admin-section" id="mdx-admin-nav-night-mode-section">
-                <tr>
-                    <th scope="row"><?php _e('夜间模式', 'mdx'); ?></th>
-                    <td>
-                        <?php $mdx_v_night_style = mdx_get_option('mdx_night_style'); ?>
-                        <select<?php if (mdx_get_option('mdx_styles_dark') !== "disable") {
-                            echo " disabled";
-                        } ?> class="mdx_stbs" name="mdx_night_style" id="mdx_night_style">
-                            <option value="true" <?php if ($mdx_v_night_style == 'true'){ ?>selected="selected"<?php } ?>><?php echo $trueon; ?></option>
-                            <option value="oled" <?php if ($mdx_v_night_style == 'oled'){ ?>selected="selected"<?php } ?>><?php echo $trueon; ?>
-                                (OLED)
-                            </option>
-                            <option value="false" <?php if ($mdx_v_night_style == 'false'){ ?>selected="selected"<?php } ?>><?php echo $falseoff; ?></option>
-                        </select>
-                        <p class="description"><?php _e('开启后，侧边栏中会出现夜间模式切换按钮。<strong>如果你启用了“黑暗主题”，那么夜间模式将会自动禁用。</strong>', 'mdx'); ?></p>
-                    </td>
-                </tr>
-                <tr>
-                    <th scope="row"><?php _e('自动夜间模式', 'mdx'); ?></th>
-                    <td>
-                        <?php $mdx_v_auto_night_style = mdx_get_option('mdx_auto_night_style'); ?>
-                        <select class="mdx_stbsip" name="mdx_auto_night_style" id="mdx_auto_night_style">
-                            <option value="system" <?php if ($mdx_v_auto_night_style == 'system'){ ?>selected="selected"<?php } ?>><?php _e("跟随系统", "mdx"); ?></option>
-                            <option value="true" <?php if ($mdx_v_auto_night_style == 'true'){ ?>selected="selected"<?php } ?>><?php echo _e("跟随时间", "mdx"); ?></option>
-                            <option value="false" <?php if ($mdx_v_auto_night_style == 'false'){ ?>selected="selected"<?php } ?>><?php echo $falseoff; ?></option>
-                        </select>
-                        <p class="description"><?php _e('<strong>仅当开启夜间模式功能后此选项方可生效。</strong></p><ul><li><code>跟随系统</code>：夜间模式随用户系统的配色方案实时切换，优先级低于用户自行设置</li><li><code>跟随时间</code>：22:30 至第二天 5:30 之间打开页面时自动加载夜间模式，优先级低于用户自行设置</li></ul>', 'mdx'); ?>
-                    </td>
-                </tr>
+            <tr>
+                <th scope="row"><?php _e( '夜间模式', 'mdx' ); ?></th>
+                <td>
+					<?php $mdx_v_night_style = mdx_get_option( 'mdx_night_style' ); ?>
+                    <select<?php if ( mdx_get_option( 'mdx_styles_dark' ) !== "disable" ) {
+						echo " disabled";
+					} ?> class="mdx_stbs" name="mdx_night_style" id="mdx_night_style">
+                        <option value="true" <?php if ( $mdx_v_night_style == 'true' ){ ?>selected="selected"<?php } ?>><?php echo $trueon; ?></option>
+                        <option value="oled" <?php if ( $mdx_v_night_style == 'oled' ){ ?>selected="selected"<?php } ?>><?php echo $trueon; ?>
+                            (OLED)
+                        </option>
+                        <option value="false" <?php if ( $mdx_v_night_style == 'false' ){ ?>selected="selected"<?php } ?>><?php echo $falseoff; ?></option>
+                    </select>
+                    <p class="description"><?php _e( '开启后，侧边栏中会出现夜间模式切换按钮。<strong>如果你启用了“黑暗主题”，那么夜间模式将会自动禁用。</strong>', 'mdx' ); ?></p>
+                </td>
+            </tr>
+            <tr>
+                <th scope="row"><?php _e( '自动夜间模式', 'mdx' ); ?></th>
+                <td>
+					<?php $mdx_v_auto_night_style = mdx_get_option( 'mdx_auto_night_style' ); ?>
+                    <select class="mdx_stbsip" name="mdx_auto_night_style" id="mdx_auto_night_style">
+                        <option value="system" <?php if ( $mdx_v_auto_night_style == 'system' ){ ?>selected="selected"<?php } ?>><?php _e( "跟随系统", "mdx" ); ?></option>
+                        <option value="true" <?php if ( $mdx_v_auto_night_style == 'true' ){ ?>selected="selected"<?php } ?>><?php _e( "跟随时间", "mdx" ); ?></option>
+                        <option value="false" <?php if ( $mdx_v_auto_night_style == 'false' ){ ?>selected="selected"<?php } ?>><?php echo $falseoff; ?></option>
+                    </select>
+                    <p class="description"><?php _e( '<strong>仅当开启夜间模式功能后此选项方可生效。</strong></p><ul><li><code>跟随系统</code>：夜间模式随用户系统的配色方案实时切换，优先级低于用户自行设置</li><li><code>跟随时间</code>：22:30 至第二天 5:30 之间打开页面时自动加载夜间模式，优先级低于用户自行设置</li></ul>', 'mdx' ); ?>
+                </td>
+            </tr>
             </tbody>
 
             <tbody class="mdx-admin-section" id="mdx-admin-nav-seo-section">
-                <tr>
-                    <th scope="row"><label for="mdx_seo_key"><?php _e('SEO 关键词', 'mdx'); ?></label></th>
-                    <td><input name="mdx_seo_key" type="text" id="mdx_seo_key"
-                            value="<?php echo esc_attr(mdx_get_option('mdx_seo_key')) ?>" class="regular-text">
-                        <p class="description" id="mdx_footer"><?php _e('用半角逗号分割关键词，数量在5个以内最佳。留空代表不开启此功能。', 'mdx'); ?></p>
-                    </td>
-                </tr>
-                <tr>
-                    <th scope="row"><?php _e('自动生成网页描述', 'mdx'); ?></th>
-                    <td>
-                        <?php $mdx_v_auto_des = mdx_get_option('mdx_auto_des'); ?>
-                        <fieldset>
-                            <label><input type="radio" name="mdx_auto_des" value="true" <?php if ($mdx_v_auto_des == 'true'){ ?>checked="checked"<?php } ?>> <?php echo $trueon; ?>
-                            </label><br>
-                            <label><input type="radio" name="mdx_auto_des" value="false" <?php if ($mdx_v_auto_des == 'false'){ ?>checked="checked"<?php } ?>> <?php echo $falseoff; ?>
-                            </label><br>
-                            <p class="description"><?php _e('开启后，会自动生成 SEO 网页描述。<strong>对首页无效，请在下方输入首页描述。</strong>', 'mdx'); ?></p>
-                        </fieldset>
-                    </td>
-                </tr>
-                <tr>
-                    <th scope="row"><label for="mdx_seo_des"><?php _e('SEO 描述', 'mdx'); ?></label></th>
-                    <td><textarea name="mdx_seo_des" id="mdx_seo_des" rows="7"
-                                cols="50"><?php echo esc_attr(mdx_get_option('mdx_seo_des')) ?></textarea>
-                        <p class="description"><?php _e('在这里编辑网页描述。如开启自动生成网页描述功能，则此空仅对首页有效，其他页面会自动生成网页描述。此空留空则表示关闭全局 SEO 描述功能。', 'mdx'); ?></p>
-                    </td>
-                </tr>
+            <tr>
+                <th scope="row"><label for="mdx_seo_key"><?php _e( 'SEO 关键词', 'mdx' ); ?></label></th>
+                <td><input name="mdx_seo_key" type="text" id="mdx_seo_key"
+                           value="<?php echo esc_attr( mdx_get_option( 'mdx_seo_key' ) ) ?>" class="regular-text">
+                    <p class="description" id="mdx_footer"><?php _e( '用半角逗号分割关键词，数量在5个以内最佳。留空代表不开启此功能。', 'mdx' ); ?></p>
+                </td>
+            </tr>
+            <tr>
+                <th scope="row"><?php _e( '自动生成网页描述', 'mdx' ); ?></th>
+                <td>
+					<?php $mdx_v_auto_des = mdx_get_option( 'mdx_auto_des' ); ?>
+                    <fieldset>
+                        <label><input type="radio" name="mdx_auto_des" value="true" <?php if ( $mdx_v_auto_des == 'true' ){ ?>checked="checked"<?php } ?>> <?php echo $trueon; ?>
+                        </label><br>
+                        <label><input type="radio" name="mdx_auto_des" value="false" <?php if ( $mdx_v_auto_des == 'false' ){ ?>checked="checked"<?php } ?>> <?php echo $falseoff; ?>
+                        </label><br>
+                        <p class="description"><?php _e( '开启后，会自动生成 SEO 网页描述。<strong>对首页无效，请在下方输入首页描述。</strong>', 'mdx' ); ?></p>
+                    </fieldset>
+                </td>
+            </tr>
+            <tr>
+                <th scope="row"><label for="mdx_seo_des"><?php _e( 'SEO 描述', 'mdx' ); ?></label></th>
+                <td><textarea name="mdx_seo_des" id="mdx_seo_des" rows="7"
+                              cols="50"><?php echo esc_attr( mdx_get_option( 'mdx_seo_des' ) ) ?></textarea>
+                    <p class="description"><?php _e( '在这里编辑网页描述。如开启自动生成网页描述功能，则此空仅对首页有效，其他页面会自动生成网页描述。此空留空则表示关闭全局 SEO 描述功能。', 'mdx' ); ?></p>
+                </td>
+            </tr>
             </tbody>
 
             <tbody class="mdx-admin-section" id="mdx-admin-nav-cdn-section">
-                <tr>
-                    <th scope="row"><label for="mdx_use_cdn"><?php _e('使用 CDN 加载前端主题文件', 'mdx'); ?></label></th>
-                    <td>
-                        <?php $mdx_v_use_cdn = mdx_get_option('mdx_use_cdn'); ?>
-                        <select name="mdx_use_cdn" id="mdx_use_cdn"
-                                onchange="mdx_cdn_sec(this.options[this.options.selectedIndex].value)">
-                            <option value="none" <?php if ($mdx_v_use_cdn == 'none'){ ?>selected="selected"<?php } ?>><?php _e('不使用', 'mdx'); ?></option>
-                            <option value="jsdelivr" <?php if ($mdx_v_use_cdn == 'jsdelivr'){ ?>selected="selected"<?php } ?>><?php _e('jsDelivr', 'mdx'); ?></option>
-                            <option value="custom" <?php if ($mdx_v_use_cdn == 'custom'){ ?>selected="selected"<?php } ?>><?php _e('自定义', 'mdx'); ?></option>
-                        </select>
-                        <p class="description"><?php _e('在<strong>部分情况</strong>下，使用 CDN 有助于前端页面更快地载入。此选项<strong>只影响</strong>主题的前端文件，不影响 WordPress 和其他插件的文件。</p><ul><li><code>不使用</code>：从和页面一致的服务器加载文件</li><li><code>jsDelivr</code>：使用由 jsDelivr 提供的免费 CDN</li><li><code>自定义</code>：使用自定义的 CDN</li></ul>', 'mdx'); ?>
-                    </td>
-                </tr>
-                <tr class="cdn_custom">
-                    <th scope="row"><?php _e('自定义 CDN 根路径', 'mdx'); ?></th>
-                    <td>
-                        <input name="mdx_custom_cdn_root" type="url" id="mdx_custom_cdn_root"
-                            value="<?php echo esc_attr(mdx_get_option('mdx_custom_cdn_root')); ?>" class="regular-text">
-                        <p class="description"><?php _e('在这里输入自定义的 CDN 根路径 URL，不要在最后添加 <code>/</code>，如 <code>https://cdn.example.com/mdx_files</code>。<br>CDN 服务需添加适当的 <code>access-control-allow-origin</code> 头。', 'mdx'); ?></p>
-                    </td>
-                </tr>
+            <tr>
+                <th scope="row"><label for="mdx_use_cdn"><?php _e( '使用 CDN 加载前端主题文件', 'mdx' ); ?></label></th>
+                <td>
+					<?php $mdx_v_use_cdn = mdx_get_option( 'mdx_use_cdn' ); ?>
+                    <select name="mdx_use_cdn" id="mdx_use_cdn"
+                            onchange="mdx_cdn_sec(this.options[this.options.selectedIndex].value)">
+                        <option value="none" <?php if ( $mdx_v_use_cdn == 'none' ){ ?>selected="selected"<?php } ?>><?php _e( '不使用', 'mdx' ); ?></option>
+                        <option value="jsdelivr" <?php if ( $mdx_v_use_cdn == 'jsdelivr' ){ ?>selected="selected"<?php } ?>><?php _e( 'jsDelivr', 'mdx' ); ?></option>
+                        <option value="custom" <?php if ( $mdx_v_use_cdn == 'custom' ){ ?>selected="selected"<?php } ?>><?php _e( '自定义', 'mdx' ); ?></option>
+                    </select>
+                    <p class="description"><?php _e( '在<strong>部分情况</strong>下，使用 CDN 有助于前端页面更快地载入。此选项<strong>只影响</strong>主题的前端文件，不影响 WordPress 和其他插件的文件。</p><ul><li><code>不使用</code>：从和页面一致的服务器加载文件</li><li><code>jsDelivr</code>：使用由 jsDelivr 提供的免费 CDN</li><li><code>自定义</code>：使用自定义的 CDN</li></ul>', 'mdx' ); ?>
+                </td>
+            </tr>
+            <tr class="cdn_custom">
+                <th scope="row"><?php _e( '自定义 CDN 根路径', 'mdx' ); ?></th>
+                <td>
+                    <input name="mdx_custom_cdn_root" type="url" id="mdx_custom_cdn_root"
+                           value="<?php echo esc_attr( mdx_get_option( 'mdx_custom_cdn_root' ) ); ?>" class="regular-text">
+                    <p class="description"><?php _e( '在这里输入自定义的 CDN 根路径 URL，不要在最后添加 <code>/</code>，如 <code>https://cdn.example.com/mdx_files</code>。<br>CDN 服务需添加适当的 <code>access-control-allow-origin</code> 头，具体可参考<a href="https://developer.mozilla.org/zh-CN/docs/Web/HTTP/Headers/Access-Control-Allow-Origin" rel="noreferrer" target="_blank">Access-Control-Allow-Origin</a>。', 'mdx' ); ?></p>
+                </td>
+            </tr>
             </tbody>
 
             <tbody class="mdx-admin-section" id="mdx-admin-nav-script-section">
-                <tr>
-                    <th scope="row"><label for="mdx_head_js"><?php _e('页头脚本', 'mdx'); ?></label></th>
-                    <td><textarea name="mdx_head_js" id="mdx_head_js" rows="7"
-                                cols="50"><?php echo mdx_get_option('mdx_head_js') ?></textarea>
-                        <p class="description"><?php _e('在这里插入脚本，会被插入至所有页面头部。', 'mdx'); ?></p></td>
-                </tr>
-                <tr>
-                    <th scope="row"><label for="mdx_footer_js"><?php _e('页尾脚本', 'mdx'); ?></label></th>
-                    <td><textarea name="mdx_footer_js" id="mdx_footer_js" rows="7"
-                                cols="50"><?php echo mdx_get_option('mdx_footer_js') ?></textarea>
-                        <p class="description"><?php _e('在这里插入脚本，会被插入至所有页面最后。', 'mdx'); ?></p></td>
-                </tr>
+            <tr>
+                <th scope="row"><label for="mdx_head_js"><?php _e( '页头脚本', 'mdx' ); ?></label></th>
+                <td><textarea name="mdx_head_js" id="mdx_head_js" rows="7"
+                              cols="50"><?php echo mdx_get_option( 'mdx_head_js' ) ?></textarea>
+                    <p class="description"><?php _e( '在这里插入脚本，会被插入至所有页面头部。', 'mdx' ); ?></p></td>
+            </tr>
+            <tr>
+                <th scope="row"><label for="mdx_footer_js"><?php _e( '页尾脚本', 'mdx' ); ?></label></th>
+                <td><textarea name="mdx_footer_js" id="mdx_footer_js" rows="7"
+                              cols="50"><?php echo mdx_get_option( 'mdx_footer_js' ) ?></textarea>
+                    <p class="description"><?php _e( '在这里插入脚本，会被插入至所有页面最后。', 'mdx' ); ?></p></td>
+            </tr>
             </tbody>
 
             <tbody class="mdx-admin-section" id="mdx-admin-nav-others-section">
-                <tr>
-                    <th scope="row"><?php _e('WordPress 安装方式', 'mdx'); ?></th>
-                    <td>
-                        <?php $mdx_v_install = mdx_get_option('mdx_install');
-                        $mdx_subdir = __('常规安装', 'mdx');
-                        if (stripos(explode('//', home_url())[1], "/")) {
-                            $mdx_subdir = __('子目录安装', 'mdx');
-                        } ?>
-                        <fieldset>
-                            <label><input type="radio" name="mdx_install" value="normal" <?php if ($mdx_v_install == 'normal'){ ?>checked="checked"<?php } ?>> <?php _e('常规', 'mdx'); ?>
-                            </label><br>
-                            <label><input type="radio" name="mdx_install" value="sub" <?php if ($mdx_v_install == 'sub'){ ?>checked="checked"<?php } ?>> <?php _e('子目录', 'mdx'); ?>
-                            </label><br>
-                            <p class="description"><?php _e('为了更好地实现某些功能，MDx 需要知道你的 WordPress 的安装方式。如果你不确定，请参考下方的检测结果。<br>MDx 检测到你的 WordPress 似乎是', 'mdx'); ?>
-                                <strong><?php echo $mdx_subdir; ?>。</strong></p>
-                        </fieldset>
-                    </td>
-                </tr>
-                <tr>
-                    <th scope="row"><label for="mdx_notice"><?php _e('网站公告', 'mdx'); ?></label></th>
-                    <td><textarea name="mdx_notice" id="mdx_notice" rows="7"
-                                cols="50"><?php echo esc_attr(mdx_get_option('mdx_notice')) ?></textarea>
-                        <p class="description"><?php _e('在这里编辑网站公告。公告会显示在首页文章列表的顶部，留空则不会显示。支持 <code>HTML</code> 格式。', 'mdx'); ?></p>
-                    </td>
-                </tr>
-                <tr>
-                    <th scope="row"><?php _e('使用手势打开抽屉菜单', 'mdx'); ?></th>
-                    <td>
-                        <?php $mdx_v_open_side = mdx_get_option('mdx_open_side'); ?>
-                        <fieldset>
-                            <label><input type="radio" name="mdx_open_side" value="true" <?php if ($mdx_v_open_side == 'true'){ ?>checked="checked"<?php } ?>> <?php echo $trueon; ?>
-                            </label><br>
-                            <label><input type="radio" name="mdx_open_side" value="false" <?php if ($mdx_v_open_side == 'false'){ ?>checked="checked"<?php } ?>> <?php echo $falseoff; ?>
-                            </label><br>
-                            <p class="description"><?php _e('开启后，可以通过从屏幕左侧向中心滑动的方式调出抽屉菜单。', 'mdx'); ?></p>
-                        </fieldset>
-                    </td>
-                </tr>
-                <tr>
-                    <th scope="row"><?php _e('右侧小工具栏', 'mdx'); ?></th>
-                    <td>
-                        <?php $mdx_v_widget = mdx_get_option('mdx_widget'); ?>
-                        <fieldset>
-                            <label><input type="radio" name="mdx_widget" value="true" <?php if ($mdx_v_widget == 'true'){ ?>checked="checked"<?php } ?>> <?php echo $trueon; ?>
-                            </label><br>
-                            <label><input type="radio" name="mdx_widget" value="false" <?php if ($mdx_v_widget == 'false'){ ?>checked="checked"<?php } ?>> <?php echo $falseoff; ?>
-                            </label><br>
-                            <p class="description"><?php _e('开启后，每个页面右下角都会显示小工具栏浮动按钮。小工具栏默认隐藏，可以通过从屏幕右侧侧向中心滑动或按钮调出右侧小工具栏。', 'mdx'); ?></p>
-                        </fieldset>
-                    </td>
-                </tr>
-                <tr>
-                    <th scope="row"><label for="mdx_cookie"><?php _e('Cookie 使用提示 (GDPR)', 'mdx'); ?></label></th>
-                    <td><textarea name="mdx_cookie" id="mdx_cookie" rows="7"
-                                cols="50"><?php echo esc_attr(mdx_get_option('mdx_cookie')) ?></textarea>
-                        <p class="description"><?php _e('Cookie 使用提示将会在用户第一次访问站点时显示，以向用户说明你站点的 Cookie 政策。如果你的站点有来自欧盟地区的访客，此选项可能会很有用。<br>在这里编辑 Cookie 使用提示，支持 <code>HTML</code>，留空则不会显示。<br>在 Safari 中，受到浏览器政策影响，提示隐藏时间最多为 7 天（不与网站交互）。要重置所有访客看到此提示的状态以向所有访客显示新的提示，请点击下方的重置按钮。', 'mdx'); ?></p>
-                        <br>
-                        <a id="reset-cookie" class="button"
-                        href="javascript:jQuery('#mdx_cookie_flag').val('mdx_cookie_<?php echo sha1(time()) ?>');jQuery('#reset-cookie').attr('disabled', 'disabled');jQuery('#reseted').show();">
-                            <?php _e('重置显示状态', 'mdx'); ?>
-                        </a>
-                        <span id="reseted" style="color:green;display:none;padding-left:10px;vertical-align:sub">
-                            <?php _e('重置成功，保存设置后生效。', 'mdx'); ?>
+            <tr>
+                <th scope="row"><?php _e( 'WordPress 安装方式', 'mdx' ); ?></th>
+                <td>
+					<?php $mdx_v_install = mdx_get_option( 'mdx_install' );
+					$mdx_subdir          = __( '常规安装', 'mdx' );
+					if ( stripos( explode( '//', home_url() )[1], "/" ) ) {
+						$mdx_subdir = __( '子目录安装', 'mdx' );
+					} ?>
+                    <fieldset>
+                        <label><input type="radio" name="mdx_install" value="normal" <?php if ( $mdx_v_install == 'normal' ){ ?>checked="checked"<?php } ?>> <?php _e( '常规', 'mdx' ); ?>
+                        </label><br>
+                        <label><input type="radio" name="mdx_install" value="sub" <?php if ( $mdx_v_install == 'sub' ){ ?>checked="checked"<?php } ?>> <?php _e( '子目录', 'mdx' ); ?>
+                        </label><br>
+                        <p class="description"><?php _e( '为了更好地实现某些功能，MDx 需要知道你的 WordPress 的安装方式。如果你不确定，请参考下方的检测结果。<br>MDx 检测到你的 WordPress 似乎是', 'mdx' ); ?>
+                            <strong><?php echo $mdx_subdir; ?>。</strong></p>
+                    </fieldset>
+                </td>
+            </tr>
+            <tr>
+                <th scope="row"><label for="mdx_notice"><?php _e( '网站公告', 'mdx' ); ?></label></th>
+                <td><textarea name="mdx_notice" id="mdx_notice" rows="7"
+                              cols="50"><?php echo esc_attr( mdx_get_option( 'mdx_notice' ) ) ?></textarea>
+                    <p class="description"><?php _e( '在这里编辑网站公告。公告会显示在首页文章列表的顶部，留空则不会显示。支持 <code>HTML</code> 格式。', 'mdx' ); ?></p>
+                </td>
+            </tr>
+            <tr>
+                <th scope="row"><?php _e( '使用手势打开抽屉菜单', 'mdx' ); ?></th>
+                <td>
+					<?php $mdx_v_open_side = mdx_get_option( 'mdx_open_side' ); ?>
+                    <fieldset>
+                        <label><input type="radio" name="mdx_open_side" value="true" <?php if ( $mdx_v_open_side == 'true' ){ ?>checked="checked"<?php } ?>> <?php echo $trueon; ?>
+                        </label><br>
+                        <label><input type="radio" name="mdx_open_side" value="false" <?php if ( $mdx_v_open_side == 'false' ){ ?>checked="checked"<?php } ?>> <?php echo $falseoff; ?>
+                        </label><br>
+                        <p class="description"><?php _e( '开启后，可以通过从屏幕左侧向中心滑动的方式调出抽屉菜单。', 'mdx' ); ?></p>
+                    </fieldset>
+                </td>
+            </tr>
+            <tr>
+                <th scope="row"><?php _e( '右侧小工具栏', 'mdx' ); ?></th>
+                <td>
+					<?php $mdx_v_widget = mdx_get_option( 'mdx_widget' ); ?>
+                    <fieldset>
+                        <label><input type="radio" name="mdx_widget" value="true" <?php if ( $mdx_v_widget == 'true' ){ ?>checked="checked"<?php } ?>> <?php echo $trueon; ?>
+                        </label><br>
+                        <label><input type="radio" name="mdx_widget" value="false" <?php if ( $mdx_v_widget == 'false' ){ ?>checked="checked"<?php } ?>> <?php echo $falseoff; ?>
+                        </label><br>
+                        <p class="description"><?php _e( '开启后，每个页面右下角都会显示小工具栏浮动按钮。小工具栏默认隐藏，可以通过从屏幕右侧侧向中心滑动或按钮调出右侧小工具栏。', 'mdx' ); ?></p>
+                    </fieldset>
+                </td>
+            </tr>
+            <tr>
+                <th scope="row"><label for="mdx_cookie"><?php _e( 'Cookie 使用提示 (GDPR)', 'mdx' ); ?></label></th>
+                <td><textarea name="mdx_cookie" id="mdx_cookie" rows="7"
+                              cols="50"><?php echo esc_attr( mdx_get_option( 'mdx_cookie' ) ) ?></textarea>
+                    <p class="description"><?php _e( 'Cookie 使用提示将会在用户第一次访问站点时显示，以向用户说明你站点的 Cookie 政策。如果你的站点有来自欧盟地区的访客，此选项可能会很有用。<br>在这里编辑 Cookie 使用提示，支持 <code>HTML</code>，留空则不会显示。<br>在 Safari 中，受到浏览器政策影响，提示隐藏时间最多为 7 天（不与网站交互）。要重置所有访客看到此提示的状态以向所有访客显示新的提示，请点击下方的重置按钮。', 'mdx' ); ?></p>
+                    <br>
+                    <a id="reset-cookie" class="button"
+                       href="javascript:jQuery('#mdx_cookie_flag').val('mdx_cookie_<?php echo sha1( time() ) ?>');jQuery('#reset-cookie').attr('disabled', 'disabled');jQuery('#reseted').show();">
+						<?php _e( '重置显示状态', 'mdx' ); ?>
+                    </a>
+                    <span id="reseted" style="color:green;display:none;padding-left:10px;vertical-align:sub">
+                            <?php _e( '重置成功，保存设置后生效。', 'mdx' ); ?>
                         </span>
-                    </td>
-                    <input type="hidden" value="<?php echo mdx_get_option('mdx_cookie_flag'); ?>" name="mdx_cookie_flag"
-                        id="mdx_cookie_flag">
-                </tr>
-                <tr>
-                    <th scope="row"><?php _e('使用 Preload 技术加速页面加载', 'mdx'); ?></th>
-                    <td>
-                        <?php $mdx_v_speed_pre = mdx_get_option('mdx_speed_pre'); ?>
-                        <fieldset>
-                            <label><input type="radio" name="mdx_speed_pre" value="true" <?php if ($mdx_v_speed_pre == 'true'){ ?>checked="checked"<?php } ?>> <?php echo $trueon; ?>
-                            </label><br>
-                            <label><input type="radio" name="mdx_speed_pre" value="false" <?php if ($mdx_v_speed_pre == 'false'){ ?>checked="checked"<?php } ?>> <?php echo $falseoff; ?>
-                            </label><br>
-                            <p class="description"><?php _e('开启后，可使用 Preload 预加载技术加速页面加载。', 'mdx'); ?></p>
-                        </fieldset>
-                    </td>
-                </tr>
-                <tr>
-                    <th scope="row"><?php _e('实时搜索', 'mdx'); ?></th>
-                    <td>
-                        <?php $mdx_v_real_search = mdx_get_option('mdx_real_search'); ?>
-                        <fieldset>
-                            <label><input type="radio" name="mdx_real_search" value="true" <?php if ($mdx_v_real_search == 'true'){ ?>checked="checked"<?php } ?>> <?php echo $trueon; ?>
-                            </label><br>
-                            <label><input type="radio" name="mdx_real_search" value="false" <?php if ($mdx_v_real_search == 'false'){ ?>checked="checked"<?php } ?>> <?php echo $falseoff; ?>
-                            </label><br>
-                            <p class="description"><?php _e('开启后，进行搜索时会随用户输入实时反馈搜索结果。<strong>需要 WordPress REST API 支持。此 API 默认开启，请确保你没有将其关闭。</strong>', 'mdx'); ?></p>
-                        </fieldset>
-                    </td>
-                </tr>
-                <tr>
-                    <th scope="row">
-                        <label for="mdx_icp_num"><?php _e('ICP 备案号', 'mdx'); ?></label>
-                    </th>
-                    <td>
-                        <input name="mdx_icp_num" type="text" id="mdx_icp_num"
-                            value="<?php echo esc_attr(mdx_get_option('mdx_icp_num')) ?>" class="regular-text">
-                        <p class="description"><?php _e('在这里填写的 ICP 备案号会显示在页脚并自动链接到 <i>中华人民共和国工业和信息化部</i> 网站，留空则不显示。如果你的服务器在中国大陆境内，这个选项可能会很有用。', 'mdx'); ?></p>
-                    </td>
-                </tr>
-                <tr>
-                    <th scope="row">
-                        <label for="mdx_wangan_num"><?php _e('公安备案号', 'mdx'); ?></label>
-                    </th>
-                    <td>
-                        <input name="mdx_wangan_num" type="text" id="mdx_wangan_num"
-                            value="<?php echo esc_attr(mdx_get_option('mdx_wangan_num')) ?>" class="regular-text">
-                        <p class="description"><?php _e('在这里填写的公安备案号会显示在页脚并自动链接到 <i>全国互联网安全管理服务平台</i> ，留空则不显示。如果你的服务器在中国大陆境内且进行了公安备案，这个选项可能会很有用。', 'mdx'); ?></p>
-                    </td>
-                </tr>
-                <tr>
-                    <th scope="row"><?php _e('在前端载入 jQuery', 'mdx'); ?></th>
-                    <td>
-                        <?php $mdx_v_jquery = mdx_get_option('mdx_jquery'); ?>
-                        <fieldset>
-                            <label><input type="radio" name="mdx_jquery" value="true" <?php if ($mdx_v_jquery == 'true'){ ?>checked="checked"<?php } ?>> <?php echo $trueon; ?>
-                            </label><br>
-                            <label><input type="radio" name="mdx_jquery" value="false" <?php if ($mdx_v_jquery == 'false'){ ?>checked="checked"<?php } ?>> <?php echo $falseoff; ?>
-                            </label><br>
-                            <p class="description"><?php _e('自 2.0.0 版本起，MDx 已不再依赖 jQuery 且不再在前端载入 jQuery 脚本。如果你在升级 MDx 后碰到页面显示不正常等问题，请尝试打开此选项。<br><strong>这是一个临时选项，将会在未来版本中被移除。如果你的前端页面中有依赖 jQuery 的其他资源，请确保其不受 MDx 移除 jQuery 的影响。</strong><br>有关更多从 MDx 1.x 升级至 2.x 的信息，请参阅<a href="https://doc.flyhigher.top/mdx/zh-CN/upgrade-tip/">主题文档</a>。', 'mdx'); ?></p>
-                        </fieldset>
-                    </td>
-                </tr>
+                </td>
+                <input type="hidden" value="<?php echo mdx_get_option( 'mdx_cookie_flag' ); ?>" name="mdx_cookie_flag"
+                       id="mdx_cookie_flag">
+            </tr>
+            <tr>
+                <th scope="row"><?php _e( '使用 Preload 技术加速页面加载', 'mdx' ); ?></th>
+                <td>
+					<?php $mdx_v_speed_pre = mdx_get_option( 'mdx_speed_pre' ); ?>
+                    <fieldset>
+                        <label><input type="radio" name="mdx_speed_pre" value="true" <?php if ( $mdx_v_speed_pre == 'true' ){ ?>checked="checked"<?php } ?>> <?php echo $trueon; ?>
+                        </label><br>
+                        <label><input type="radio" name="mdx_speed_pre" value="false" <?php if ( $mdx_v_speed_pre == 'false' ){ ?>checked="checked"<?php } ?>> <?php echo $falseoff; ?>
+                        </label><br>
+                        <p class="description"><?php _e( '开启后，可使用 Preload 预加载技术加速页面加载。', 'mdx' ); ?></p>
+                    </fieldset>
+                </td>
+            </tr>
+            <tr>
+                <th scope="row"><?php _e( '实时搜索', 'mdx' ); ?></th>
+                <td>
+					<?php $mdx_v_real_search = mdx_get_option( 'mdx_real_search' ); ?>
+                    <fieldset>
+                        <label><input type="radio" name="mdx_real_search" value="true" <?php if ( $mdx_v_real_search == 'true' ){ ?>checked="checked"<?php } ?>> <?php echo $trueon; ?>
+                        </label><br>
+                        <label><input type="radio" name="mdx_real_search" value="false" <?php if ( $mdx_v_real_search == 'false' ){ ?>checked="checked"<?php } ?>> <?php echo $falseoff; ?>
+                        </label><br>
+                        <p class="description"><?php _e( '开启后，进行搜索时会随用户输入实时反馈搜索结果。<strong>需要 WordPress REST API 支持。此 API 默认开启，请确保你没有将其关闭。</strong>', 'mdx' ); ?></p>
+                    </fieldset>
+                </td>
+            </tr>
+            <tr>
+                <th scope="row">
+                    <label for="mdx_icp_num"><?php _e( 'ICP 备案号', 'mdx' ); ?></label>
+                </th>
+                <td>
+                    <input name="mdx_icp_num" type="text" id="mdx_icp_num"
+                           value="<?php echo esc_attr( mdx_get_option( 'mdx_icp_num' ) ) ?>" class="regular-text">
+                    <p class="description"><?php _e( '在这里填写的 ICP 备案号会显示在页脚并自动链接到 <i>中华人民共和国工业和信息化部</i> 网站，留空则不显示。如果你的服务器在中国大陆境内，这个选项可能会很有用。', 'mdx' ); ?></p>
+                </td>
+            </tr>
+            <tr>
+                <th scope="row">
+                    <label for="mdx_wangan_num"><?php _e( '公安备案号', 'mdx' ); ?></label>
+                </th>
+                <td>
+                    <input name="mdx_wangan_num" type="text" id="mdx_wangan_num"
+                           value="<?php echo esc_attr( mdx_get_option( 'mdx_wangan_num' ) ) ?>" class="regular-text">
+                    <p class="description"><?php _e( '在这里填写的公安备案号会显示在页脚并自动链接到 <i>全国互联网安全管理服务平台</i> ，留空则不显示。如果你的服务器在中国大陆境内且进行了公安备案，这个选项可能会很有用。', 'mdx' ); ?></p>
+                </td>
+            </tr>
+            <tr>
+                <th scope="row"><?php _e( '在前端载入 jQuery', 'mdx' ); ?></th>
+                <td>
+					<?php $mdx_v_jquery = mdx_get_option( 'mdx_jquery' ); ?>
+                    <fieldset>
+                        <label><input type="radio" name="mdx_jquery" value="true" <?php if ( $mdx_v_jquery == 'true' ){ ?>checked="checked"<?php } ?>> <?php echo $trueon; ?>
+                        </label><br>
+                        <label><input type="radio" name="mdx_jquery" value="false" <?php if ( $mdx_v_jquery == 'false' ){ ?>checked="checked"<?php } ?>> <?php echo $falseoff; ?>
+                        </label><br>
+                        <p class="description"><?php _e( '自 2.0.0 版本起，MDx 已不再依赖 jQuery 且不再在前端载入 jQuery 脚本。如果你在升级 MDx 后碰到页面显示不正常等问题，请尝试打开此选项。<br><strong>这是一个临时选项，将会在未来版本中被移除。如果你的前端页面中有依赖 jQuery 的其他资源，请确保其不受 MDx 移除 jQuery 的影响。</strong><br>有关更多从 MDx 1.x 升级至 2.x 的信息，请参阅<a href="https://doc.flyhigher.top/mdx/zh-CN/upgrade-tip/">主题文档</a>。', 'mdx' ); ?></p>
+                    </fieldset>
+                </td>
+            </tr>
             </tbody>
         </table><?php submit_button(); ?></form>
 </div>

--- a/admin_style.php
+++ b/admin_style.php
@@ -1,823 +1,920 @@
 <?php
 settings_errors();
-$trueon=__('开启', 'mdx');
-$falseoff=__('关闭', 'mdx');
+$trueon   = __( '开启', 'mdx' );
+$falseoff = __( '关闭', 'mdx' );
 
 //Some errors happend. I can't use WordPress Setting API. It said "Error: options page not found.", so I used another way to save the values.
-wp_enqueue_script('media-upload');
-wp_enqueue_script('my-upload', get_bloginfo('template_url' ).'/js/admin_upload.js');
+wp_enqueue_script( 'media-upload' );
+wp_enqueue_script( 'my-upload', get_bloginfo( 'template_url' ) . '/js/admin_upload.js' );
 wp_enqueue_media();
-wp_enqueue_script('thickbox');
-wp_enqueue_style('thickbox');
-wp_enqueue_style('wp-color-picker');
-wp_enqueue_script('wp-color-picker');
+wp_enqueue_script( 'thickbox' );
+wp_enqueue_style( 'thickbox' );
+wp_enqueue_style( 'wp-color-picker' );
+wp_enqueue_script( 'wp-color-picker' );
 ?>
-<div class="wrap"><h1><?php _e('MDx 主题 - 样式', 'mdx');?></h1>
-<?php
-if((isset($_POST['mdx_ref']) && $_POST['mdx_ref'] == 'true') && check_admin_referer('mdx_options_update')){
-    $mdx_color_arr=array(
-        'red'=>'#f44336',
-        'pink'=>'#e91e63',
-        'purple'=>'#9c27b0',
-        'deep-purple'=>'#673ab7',
-        'indigo'=>'#3f51b5',
-        'blue'=>'#2196f3',
-        'light-blue'=>'#03a9f4',
-        'cyan'=>'#00bcd4',
-        'teal'=>'#009688',
-        'green'=>'#4caf50',
-        'light-green'=>'#8bc34a',
-        'lime'=>'#cddc39',
-        'yellow'=>'#ffeb3b',
-        'amber'=>'#ffc107',
-        'orange'=>'#ff9800',
-        'deep-orange'=>'#ff5722',
-        'brown'=>'#795548',
-        'grey'=>'#9e9e9e',
-        'blue-grey'=>'#607d8b',
-        'white'=>'#9e9e9e',
-    );
-    $mdx_act_arr=array(
-        'red'=>'#ff5252',
-        'pink'=>'#ff4081',
-        'purple'=>'#e040fb',
-        'deep-purple'=>'#7c4dff',
-        'indigo'=>'#536dfe',
-        'blue'=>'#448aff',
-        'light-blue'=>'#40c4ff',
-        'cyan'=>'#18ffff',
-        'teal'=>'#64ffda',
-        'green'=>'#69f0ae',
-        'light-green'=>'#b2ff59',
-        'lime'=>'#eeff41',
-        'yellow'=>'#ffff00',
-        'amber'=>'#ffd740',
-        'orange'=>'#ffab40',
-        'deep-orange'=>'#ff6e40',
-    );
-    mdx_update_option('mdx_styles', sanitize_text_field($_POST['mdx_styles']));
-    mdx_update_option('mdx_styles_hex', $mdx_color_arr[sanitize_text_field($_POST['mdx_styles'])]);
-    mdx_update_option('mdx_styles_act', sanitize_text_field($_POST['mdx_styles_act']));
-    mdx_update_option('mdx_act_hex', $mdx_act_arr[sanitize_text_field($_POST['mdx_styles_act'])]);
-    mdx_update_option('mdx_styles_dark', sanitize_text_field($_POST['mdx_styles_dark']));
-    if($_POST['mdx_styles_dark'] !== "disable"){
-        mdx_update_option('mdx_night_style', 'false');
-        mdx_update_option('mdx_auto_night_style', 'false');
-    }
-    mdx_update_option('mdx_md2', $_POST['mdx_md2']);
-    $md2_font = sanitize_text_field($_POST['mdx_md2_font']);
-    if(isset($md2_font)){
-        mdx_update_option('mdx_md2_font', $md2_font);
-    }else{
-        mdx_update_option('mdx_md2_font', 'false');
-    }
-    mdx_update_option('mdx_login_md', sanitize_text_field($_POST['mdx_login_md']));
-    mdx_update_option('mdx_chrome_color', sanitize_text_field($_POST['mdx_chrome_color']));
-    mdx_update_option('mdx_title_bar', sanitize_text_field($_POST['mdx_title_bar']));
-    mdx_update_option('mdx_tap_to_top', sanitize_text_field($_POST['mdx_tap_to_top']));
-    mdx_update_option('mdx_default_style', sanitize_text_field($_POST['mdx_default_style']));
-    mdx_update_option('mdx_index_show', sanitize_text_field($_POST['mdx_index_show']));
-    mdx_update_option('mdx_post_style', sanitize_text_field($_POST['mdx_post_style']));
-    mdx_update_option('mdx_post_time_positon', sanitize_text_field($_POST['mdx_post_time_positon']));
-    mdx_update_option('mdx_post_nav_style', sanitize_text_field($_POST['mdx_post_nav_style']));
-    mdx_update_option('mdx_post_list_width', sanitize_text_field($_POST['mdx_post_list_width']));
-    mdx_update_option('mdx_echo_post_sum', sanitize_text_field($_POST['mdx_echo_post_sum']));
-    mdx_update_option('mdx_post_list_img_height', sanitize_text_field($_POST['mdx_post_list_img_height']));
-    mdx_update_option('mdx_post_def_img', sanitize_text_field($_POST['mdx_post_def_img']));
-    if ($_POST['mdx_post_def_img_url'] === '') {
-        global $files_root;
-        mdx_update_option('mdx_post_def_img_url', esc_url_raw($files_root.'/img/dpic.jpg'));
-    } else {
-        mdx_update_option('mdx_post_def_img_url', esc_url_raw($_POST['mdx_post_def_img_url']));
-    }
-    mdx_update_option('mdx_gravatar_actived', sanitize_text_field($_POST['mdx_gravatar_actived']));
-    mdx_update_option('mdx_link_rand_order', sanitize_text_field($_POST['mdx_link_rand_order']));
-    mdx_update_option('mdx_title_med', sanitize_text_field($_POST['mdx_title_med']));
-    mdx_update_option('mdx_index_head_style', sanitize_text_field($_POST['mdx_index_head_style']));
-    mdx_update_option('mdx_index_slide_posts_style', sanitize_text_field($_POST['mdx_index_slide_posts_style']));
-    mdx_update_option('mdx_index_slide_posts_num', sanitize_text_field($_POST['mdx_index_slide_posts_num']));
-    mdx_update_option('mdx_index_slide_interval', sanitize_text_field($_POST['mdx_index_slide_interval']));
-    mdx_update_option('mdx_index_slide_posts_get', sanitize_text_field($_POST['mdx_index_slide_posts_get']));
-    mdx_update_option('mdx_index_slide_posts_cat', sanitize_text_field($_POST['mdx_index_slide_posts_cat']));
-    mdx_update_option('mdx_index_img', sanitize_text_field($_POST['mdx_index_img']));
-    mdx_update_option('mdx_index_img_bg', sanitize_text_field($_POST['mdx_index_img_bg']));
-    mdx_update_option('mdx_side_img', esc_url_raw($_POST['mdx_side_img']));
-    mdx_update_option('mdx_side_info', sanitize_text_field($_POST['mdx_side_info']));
-    mdx_update_option('mdx_side_head', esc_url_raw($_POST['mdx_side_head']));
-    mdx_update_option('mdx_side_name', htmlentities(stripslashes($_POST['mdx_side_name'])));
-    mdx_update_option('mdx_side_more', htmlentities(stripslashes($_POST['mdx_side_more'])));
-    mdx_update_option('mdx_index_say', htmlentities(stripslashes($_POST['mdx_index_say'])));
-    mdx_update_option('mdx_index_say_size', sanitize_text_field($_POST['mdx_index_say_size']));
-    mdx_update_option('mdx_say_after', htmlentities(stripslashes($_POST['mdx_say_after'])));
-    mdx_update_option('mdx_logo_way', sanitize_text_field($_POST['mdx_logo_way']));
-    mdx_update_option('mdx_logo', esc_url_raw($_POST['mdx_logo']));
-    mdx_update_option('mdx_logo_text', sanitize_text_field($_POST['mdx_logo_text']));
-    mdx_update_option('mdx_safari', sanitize_text_field($_POST['mdx_safari']));
-    mdx_update_option('mdx_svg', esc_url_raw($_POST['mdx_svg']));
-    mdx_update_option('mdx_svg_color', sanitize_text_field($_POST['mdx_svg_color']));
-    mdx_update_option('mdx_tags_color', sanitize_text_field($_POST['mdx_tags_color']));
-    mdx_update_option('mdx_styles_footer', sanitize_text_field($_POST['mdx_styles_footer']));
-    if ($_POST['mdx_footer_say'] === 'jkrQnlLIIa6K4b$DuR') {
-        mdx_update_option('mdx_hide_footer', mdx_get_option('mdx_hide_footer') === 'true' ? 'false' : 'true');
-    } else {
-        mdx_update_option('mdx_footer_say', htmlentities(stripslashes($_POST['mdx_footer_say'])));
-    }
-    mdx_update_option('mdx_footer', htmlentities(stripslashes($_POST['mdx_footer'])));
-?>
-<div class="notice notice-success is-dismissible">
-<p><?php _e('设置已保存。', 'mdx'); ?></p>
+<div class="wrap"><h1><?php _e( 'MDx 主题 - 样式', 'mdx' ); ?></h1>
+	<?php
+	if ( ( isset( $_POST['mdx_ref'] ) && $_POST['mdx_ref'] == 'true' ) && check_admin_referer( 'mdx_options_update' ) ) {
+		$mdx_color_arr = array(
+			'red'         => '#f44336',
+			'pink'        => '#e91e63',
+			'purple'      => '#9c27b0',
+			'deep-purple' => '#673ab7',
+			'indigo'      => '#3f51b5',
+			'blue'        => '#2196f3',
+			'light-blue'  => '#03a9f4',
+			'cyan'        => '#00bcd4',
+			'teal'        => '#009688',
+			'green'       => '#4caf50',
+			'light-green' => '#8bc34a',
+			'lime'        => '#cddc39',
+			'yellow'      => '#ffeb3b',
+			'amber'       => '#ffc107',
+			'orange'      => '#ff9800',
+			'deep-orange' => '#ff5722',
+			'brown'       => '#795548',
+			'grey'        => '#9e9e9e',
+			'blue-grey'   => '#607d8b',
+			'white'       => '#9e9e9e',
+		);
+		$mdx_act_arr   = array(
+			'red'         => '#ff5252',
+			'pink'        => '#ff4081',
+			'purple'      => '#e040fb',
+			'deep-purple' => '#7c4dff',
+			'indigo'      => '#536dfe',
+			'blue'        => '#448aff',
+			'light-blue'  => '#40c4ff',
+			'cyan'        => '#18ffff',
+			'teal'        => '#64ffda',
+			'green'       => '#69f0ae',
+			'light-green' => '#b2ff59',
+			'lime'        => '#eeff41',
+			'yellow'      => '#ffff00',
+			'amber'       => '#ffd740',
+			'orange'      => '#ffab40',
+			'deep-orange' => '#ff6e40',
+		);
+		mdx_update_option( 'mdx_styles', sanitize_text_field( $_POST['mdx_styles'] ) );
+		mdx_update_option( 'mdx_styles_hex', $mdx_color_arr[ sanitize_text_field( $_POST['mdx_styles'] ) ] );
+		mdx_update_option( 'mdx_styles_act', sanitize_text_field( $_POST['mdx_styles_act'] ) );
+		mdx_update_option( 'mdx_act_hex', $mdx_act_arr[ sanitize_text_field( $_POST['mdx_styles_act'] ) ] );
+		mdx_update_option( 'mdx_styles_dark', sanitize_text_field( $_POST['mdx_styles_dark'] ) );
+		if ( $_POST['mdx_styles_dark'] !== "disable" ) {
+			mdx_update_option( 'mdx_night_style', 'false' );
+			mdx_update_option( 'mdx_auto_night_style', 'false' );
+		}
+		mdx_update_option( 'mdx_md2', $_POST['mdx_md2'] );
+		$md2_font = sanitize_text_field( $_POST['mdx_md2_font'] );
+		if ( isset( $md2_font ) ) {
+			mdx_update_option( 'mdx_md2_font', $md2_font );
+		} else {
+			mdx_update_option( 'mdx_md2_font', 'false' );
+		}
+		mdx_update_option( 'mdx_login_md', sanitize_text_field( $_POST['mdx_login_md'] ) );
+		mdx_update_option( 'mdx_chrome_color', sanitize_text_field( $_POST['mdx_chrome_color'] ) );
+		mdx_update_option( 'mdx_title_bar', sanitize_text_field( $_POST['mdx_title_bar'] ) );
+		mdx_update_option( 'mdx_tap_to_top', sanitize_text_field( $_POST['mdx_tap_to_top'] ) );
+		mdx_update_option( 'mdx_default_style', sanitize_text_field( $_POST['mdx_default_style'] ) );
+		mdx_update_option( 'mdx_index_show', sanitize_text_field( $_POST['mdx_index_show'] ) );
+		mdx_update_option( 'mdx_post_style', sanitize_text_field( $_POST['mdx_post_style'] ) );
+		mdx_update_option( 'mdx_post_time_positon', sanitize_text_field( $_POST['mdx_post_time_positon'] ) );
+		mdx_update_option( 'mdx_post_nav_style', sanitize_text_field( $_POST['mdx_post_nav_style'] ) );
+		mdx_update_option( 'mdx_post_list_width', sanitize_text_field( $_POST['mdx_post_list_width'] ) );
+		mdx_update_option( 'mdx_echo_post_sum', sanitize_text_field( $_POST['mdx_echo_post_sum'] ) );
+		mdx_update_option( 'mdx_post_list_img_height', sanitize_text_field( $_POST['mdx_post_list_img_height'] ) );
+		mdx_update_option( 'mdx_post_def_img', sanitize_text_field( $_POST['mdx_post_def_img'] ) );
+		if ( $_POST['mdx_post_def_img_url'] === '' ) {
+			global $files_root;
+			mdx_update_option( 'mdx_post_def_img_url', esc_url_raw( $files_root . '/img/dpic.jpg' ) );
+		} else {
+			mdx_update_option( 'mdx_post_def_img_url', esc_url_raw( $_POST['mdx_post_def_img_url'] ) );
+		}
+		mdx_update_option( 'mdx_gravatar_actived', sanitize_text_field( $_POST['mdx_gravatar_actived'] ) );
+		mdx_update_option( 'mdx_link_rand_order', sanitize_text_field( $_POST['mdx_link_rand_order'] ) );
+		mdx_update_option( 'mdx_title_med', sanitize_text_field( $_POST['mdx_title_med'] ) );
+		mdx_update_option( 'mdx_index_head_style', sanitize_text_field( $_POST['mdx_index_head_style'] ) );
+		mdx_update_option( 'mdx_index_slide_posts_style', sanitize_text_field( $_POST['mdx_index_slide_posts_style'] ) );
+		mdx_update_option( 'mdx_index_slide_posts_num', sanitize_text_field( $_POST['mdx_index_slide_posts_num'] ) );
+		mdx_update_option( 'mdx_index_slide_interval', sanitize_text_field( $_POST['mdx_index_slide_interval'] ) );
+		mdx_update_option( 'mdx_index_slide_posts_get', sanitize_text_field( $_POST['mdx_index_slide_posts_get'] ) );
+		mdx_update_option( 'mdx_index_slide_posts_cat', sanitize_text_field( $_POST['mdx_index_slide_posts_cat'] ) );
+		mdx_update_option( 'mdx_index_img', sanitize_text_field( $_POST['mdx_index_img'] ) );
+		mdx_update_option( 'mdx_index_img_bg', sanitize_text_field( $_POST['mdx_index_img_bg'] ) );
+		mdx_update_option( 'mdx_side_img', esc_url_raw( $_POST['mdx_side_img'] ) );
+		mdx_update_option( 'mdx_side_info', sanitize_text_field( $_POST['mdx_side_info'] ) );
+		mdx_update_option( 'mdx_side_head', esc_url_raw( $_POST['mdx_side_head'] ) );
+		mdx_update_option( 'mdx_side_name', htmlentities( stripslashes( $_POST['mdx_side_name'] ) ) );
+		mdx_update_option( 'mdx_side_more', htmlentities( stripslashes( $_POST['mdx_side_more'] ) ) );
+		mdx_update_option( 'mdx_index_say', htmlentities( stripslashes( $_POST['mdx_index_say'] ) ) );
+		mdx_update_option( 'mdx_index_say_size', sanitize_text_field( $_POST['mdx_index_say_size'] ) );
+		mdx_update_option( 'mdx_say_after', htmlentities( stripslashes( $_POST['mdx_say_after'] ) ) );
+		mdx_update_option( 'mdx_logo_way', sanitize_text_field( $_POST['mdx_logo_way'] ) );
+		mdx_update_option( 'mdx_logo', esc_url_raw( $_POST['mdx_logo'] ) );
+		mdx_update_option( 'mdx_logo_text', sanitize_text_field( $_POST['mdx_logo_text'] ) );
+		mdx_update_option( 'mdx_safari', sanitize_text_field( $_POST['mdx_safari'] ) );
+		mdx_update_option( 'mdx_svg', esc_url_raw( $_POST['mdx_svg'] ) );
+		mdx_update_option( 'mdx_svg_color', sanitize_text_field( $_POST['mdx_svg_color'] ) );
+		mdx_update_option( 'mdx_tags_color', sanitize_text_field( $_POST['mdx_tags_color'] ) );
+		mdx_update_option( 'mdx_styles_footer', sanitize_text_field( $_POST['mdx_styles_footer'] ) );
+		if ( $_POST['mdx_footer_say'] === 'jkrQnlLIIa6K4b$DuR' ) {
+			mdx_update_option( 'mdx_hide_footer', mdx_get_option( 'mdx_hide_footer' ) === 'true' ? 'false' : 'true' );
+		} else {
+			mdx_update_option( 'mdx_footer_say', htmlentities( stripslashes( $_POST['mdx_footer_say'] ) ) );
+		}
+		mdx_update_option( 'mdx_footer', htmlentities( stripslashes( $_POST['mdx_footer'] ) ) );
+		?>
+        <div class="notice notice-success is-dismissible">
+            <p><?php _e( '设置已保存。', 'mdx' ); ?></p>
+        </div>
+		<?php
+	} else if ( ( isset( $_POST['mdx_ref'] ) && $_POST['mdx_ref'] == 'true' ) && ! ( check_admin_referer( 'mdx_options_update' ) ) ) {
+		?>
+        <div class="notice notice-error is-dismissible">
+            <p><?php _e( '更改未能保存。', 'mdx' ); ?></p>
+        </div>
+		<?php
+	} ?>
+	<?php if ( get_option( 'mdx_new_ver' ) != get_option( 'mdx_version' ) ) { ?>
+        <div class="notice notice-info is-dismissible">
+            <p><?php _e( 'MDx 已发布新版本 ', 'mdx' );
+				echo get_option( 'mdx_new_ver' );
+				_e( '。<a href="./admin.php?page=mdx_about">重新检查</a>', 'mdx' ); ?></p>
+        </div>
+	<?php }
+	if ( ! defined( 'ALU_VERSION' ) ) {
+		define( 'ALU_VERSION', '1.0.6' );
+	}
+	if ( ALU_VERSION !== '1.0.6' ) {
+		?>
+        <div class="notice notice-warning is-dismissible">
+            <p><?php _e( '你似乎正在使用旧版本的 Alu 表情插件。这与 MDx 2.x 不兼容，你需要前往 <a href="https://doc.flyhigher.top/mdx/zh-CN/config/emoji-in-comment/" target="_blank">MDx 文档</a> 下载安装新版插件。', 'mdx' ); ?></p>
+        </div>
+	<?php } ?>
+    <nav class="nav-tab-wrapper wp-clearfix" aria-label="Secondary menu">
+        <a href="#" class="nav-tab nav-tab-active mdx-admin-nav" id="mdx-admin-nav-global"><?php _e( '全局', 'mdx' ); ?></a>
+        <a href="#" class="nav-tab mdx-admin-nav" id="mdx-admin-nav-index"><?php _e( '首页', 'mdx' ); ?></a>
+        <a href="#" class="nav-tab mdx-admin-nav" id="mdx-admin-nav-post"><?php _e( '文章页', 'mdx' ); ?></a>
+        <a href="#" class="nav-tab mdx-admin-nav" id="mdx-admin-nav-post-list"><?php _e( '文章列表', 'mdx' ); ?></a>
+        <a href="#" class="nav-tab mdx-admin-nav" id="mdx-admin-nav-title-bar"><?php _e( '标题栏', 'mdx' ); ?></a>
+        <a href="#" class="nav-tab mdx-admin-nav" id="mdx-admin-nav-drawer"><?php _e( '抽屉菜单', 'mdx' ); ?></a>
+        <a href="#" class="nav-tab mdx-admin-nav" id="mdx-admin-nav-footer"><?php _e( '页脚', 'mdx' ); ?></a>
+        <a href="#" class="nav-tab mdx-admin-nav" id="mdx-admin-nav-touch-bar-icon"><?php _e( 'Touch Bar 图标', 'mdx' ); ?></a>
+        <a href="#" class="nav-tab mdx-admin-nav" id="mdx-admin-nav-others"><?php _e( '杂项', 'mdx' ); ?></a>
+    </nav>
+    <form method="post" action="">
+		<?php
+		wp_nonce_field( 'mdx_options_update' );
+		?>
+        <input type='hidden' name='mdx_ref' value='true'>
+        <table class="form-table">
+            <tbody class="mdx-admin-section mdx-admin-section-active" id="mdx-admin-nav-global-section">
+            <tr>
+                <th scope="row"><label for="mdx_styles"><?php _e( '主题颜色', 'mdx' ); ?></label></th>
+                <td>
+					<?php $mdx_v_styles = mdx_get_option( 'mdx_styles' ); ?>
+                    <select name="mdx_styles" id="mdx_styles">
+                        <option value="red" <?php if ( $mdx_v_styles == 'red' ){ ?>selected="selected"<?php } ?>>Red</option>
+                        <option value="pink" <?php if ( $mdx_v_styles == 'pink' ){ ?>selected="selected"<?php } ?>>Pink</option>
+                        <option value="purple" <?php if ( $mdx_v_styles == 'purple' ){ ?>selected="selected"<?php } ?>>Purple</option>
+                        <option value="deep-purple" <?php if ( $mdx_v_styles == 'deep-purple' ){ ?>selected="selected"<?php } ?>>Deep Purple</option>
+                        <option value="indigo" <?php if ( $mdx_v_styles == 'indigo' ){ ?>selected="selected"<?php } ?>>Indigo</option>
+                        <option value="blue" <?php if ( $mdx_v_styles == 'blue' ){ ?>selected="selected"<?php } ?>>Blue</option>
+                        <option value="light-blue" <?php if ( $mdx_v_styles == 'light-blue' ){ ?>selected="selected"<?php } ?>>Light Blue</option>
+                        <option value="cyan" <?php if ( $mdx_v_styles == 'cyan' ){ ?>selected="selected"<?php } ?>>Cyan</option>
+                        <option value="teal" <?php if ( $mdx_v_styles == 'teal' ){ ?>selected="selected"<?php } ?>>Teal</option>
+                        <option value="green" <?php if ( $mdx_v_styles == 'green' ){ ?>selected="selected"<?php } ?>>Green</option>
+                        <option value="light-green" <?php if ( $mdx_v_styles == 'light-green' ){ ?>selected="selected"<?php } ?>>Light Green</option>
+                        <option value="lime" <?php if ( $mdx_v_styles == 'lime' ){ ?>selected="selected"<?php } ?>>Lime</option>
+                        <option value="yellow" <?php if ( $mdx_v_styles == 'yellow' ){ ?>selected="selected"<?php } ?>>Yellow</option>
+                        <option value="amber" <?php if ( $mdx_v_styles == 'amber' ){ ?>selected="selected"<?php } ?>>Amber</option>
+                        <option value="orange" <?php if ( $mdx_v_styles == 'orange' ){ ?>selected="selected"<?php } ?>>Orange</option>
+                        <option value="deep-orange" <?php if ( $mdx_v_styles == 'deep-orange' ){ ?>selected="selected"<?php } ?>>Deep Orange</option>
+                        <option value="brown" <?php if ( $mdx_v_styles == 'brown' ){ ?>selected="selected"<?php } ?>>Brown</option>
+                        <option value="grey" <?php if ( $mdx_v_styles == 'grey' ){ ?>selected="selected"<?php } ?>>Grey</option>
+                        <option value="blue-grey" <?php if ( $mdx_v_styles == 'blue-grey' ){ ?>selected="selected"<?php } ?>>Blue Grey</option>
+                        <option value="white" <?php if ( $mdx_v_styles == 'white' ){ ?>selected="selected"<?php } ?>>White</option>
+                    </select>
+                    <p class="description">
+                        <span class="mdx-color-preview mdx-theme-color-preview"></span> <?php _e( '主题颜色会影响所有页面的主色。', 'mdx' ); ?>
+                    </p>
+                </td>
+            </tr>
+            <tr>
+                <th scope="row"><label for="mdx_styles_act"><?php _e( '强调颜色', 'mdx' ); ?></label></th>
+                <td>
+					<?php $mdx_v_styles_act = mdx_get_option( 'mdx_styles_act' ); ?>
+                    <select name="mdx_styles_act" id="mdx_styles_act">
+                        <option value="red" <?php if ( $mdx_v_styles_act == 'red' ){ ?>selected="selected"<?php } ?>>Red</option>
+                        <option value="pink" <?php if ( $mdx_v_styles_act == 'pink' ){ ?>selected="selected"<?php } ?>>Pink</option>
+                        <option value="purple" <?php if ( $mdx_v_styles_act == 'purple' ){ ?>selected="selected"<?php } ?>>Purple</option>
+                        <option value="deep-purple" <?php if ( $mdx_v_styles_act == 'deep-purple' ){ ?>selected="selected"<?php } ?>>Deep Purple</option>
+                        <option value="indigo" <?php if ( $mdx_v_styles_act == 'indigo' ){ ?>selected="selected"<?php } ?>>Indigo</option>
+                        <option value="blue" <?php if ( $mdx_v_styles_act == 'blue' ){ ?>selected="selected"<?php } ?>>Blue</option>
+                        <option value="light-blue" <?php if ( $mdx_v_styles_act == 'light-blue' ){ ?>selected="selected"<?php } ?>>Light Blue</option>
+                        <option value="cyan" <?php if ( $mdx_v_styles_act == 'cyan' ){ ?>selected="selected"<?php } ?>>Cyan</option>
+                        <option value="teal" <?php if ( $mdx_v_styles_act == 'teal' ){ ?>selected="selected"<?php } ?>>Teal</option>
+                        <option value="green" <?php if ( $mdx_v_styles_act == 'green' ){ ?>selected="selected"<?php } ?>>Green</option>
+                        <option value="light-green" <?php if ( $mdx_v_styles_act == 'light-green' ){ ?>selected="selected"<?php } ?>>Light Green</option>
+                        <option value="lime" <?php if ( $mdx_v_styles_act == 'lime' ){ ?>selected="selected"<?php } ?>>Lime</option>
+                        <option value="yellow" <?php if ( $mdx_v_styles_act == 'yellow' ){ ?>selected="selected"<?php } ?>>Yellow</option>
+                        <option value="amber" <?php if ( $mdx_v_styles_act == 'amber' ){ ?>selected="selected"<?php } ?>>Amber</option>
+                        <option value="orange" <?php if ( $mdx_v_styles_act == 'orange' ){ ?>selected="selected"<?php } ?>>Orange</option>
+                        <option value="deep-orange" <?php if ( $mdx_v_styles_act == 'deep-orange' ){ ?>selected="selected"<?php } ?>>Deep Orange</option>
+                    </select>
+                    <p class="description">
+                        <span class="mdx-color-preview mdx-accent-color-preview"></span> <?php _e( '强调颜色会影响所有页面的强调色。', 'mdx' ); ?>
+                    </p>
+                </td>
+            </tr>
+            <tr>
+                <th scope="row"><label for="mdx_styles_dark"><?php _e( '黑暗主题', 'mdx' ); ?></label></th>
+                <td>
+					<?php $mdx_v_styles_dark = mdx_get_option( 'mdx_styles_dark' ); ?>
+                    <select name="mdx_styles_dark" id="mdx_styles_dark">
+                        <option value="disable" <?php if ( $mdx_v_styles_dark == 'disable' ){ ?>selected="selected"<?php } ?>><?php _e( '禁用', 'mdx' ); ?></option>
+                        <option value="dark" <?php if ( $mdx_v_styles_dark == 'dark' ){ ?>selected="selected"<?php } ?>><?php _e( '启用', 'mdx' ); ?></option>
+                        <option value="oled" <?php if ( $mdx_v_styles_dark == 'oled' ){ ?>selected="selected"<?php } ?>><?php _e( '启用 (OLED)', 'mdx' ); ?></option>
+                    </select>
+                    <p class="description"><?php _e( '如果启用，页面将忽略夜间模式相关设置并强制始终以黑暗主题显示。', 'mdx' ); ?></p>
+                </td>
+            </tr>
+            <tr>
+                <th scope="row"><?php _e( 'Material Design 2', 'mdx' ); ?></th>
+                <td>
+					<?php $mdx_v_md2 = mdx_get_option( 'mdx_md2' ); ?>
+                    <fieldset>
+                        <label><input type="radio" class="md2" name="mdx_md2" value="true" <?php if ( $mdx_v_md2 == 'true' ){ ?>checked="checked"<?php } ?>> <?php echo $trueon; ?>
+                        </label><br>
+                        <label><input type="radio" class="md2" name="mdx_md2" value="false" <?php if ( $mdx_v_md2 == 'false' ){ ?>checked="checked"<?php } ?>> <?php echo $falseoff; ?>
+                        </label><br>
+                        <p class="description"><?php _e( '开启后，主题将会使用 Material Design 2 风格。', 'mdx' ); ?></p>
+                    </fieldset>
+                </td>
+            </tr>
+            <tr class="md2_font">
+                <th scope="row"><?php _e( 'Material Design 2 字体', 'mdx' ); ?></th>
+                <td>
+					<?php $mdx_v_md2_font = mdx_get_option( 'mdx_md2_font' ); ?>
+                    <fieldset>
+                        <label><input type="radio" name="mdx_md2_font" value="true" <?php if ( $mdx_v_md2_font == 'true' ){ ?>checked="checked"<?php } ?>> <?php echo $trueon; ?>
+                        </label><br>
+                        <label><input type="radio" name="mdx_md2_font" value="false" <?php if ( $mdx_v_md2_font == 'false' ){ ?>checked="checked"<?php } ?>> <?php echo $falseoff; ?>
+                        </label><br>
+                        <p class="description"><?php _e( '开启后，部分标题文字将会使用 Material Design 2 风格字体显示。<strong>请注意该字体仅包含拉丁字符。</strong>', 'mdx' ); ?></p>
+                    </fieldset>
+                </td>
+            </tr>
+            <tr>
+                <th scope="row"><?php _e( '移动 Chrome 标题栏颜色', 'mdx' ); ?></th>
+                <td>
+					<?php $mdx_v_chrome_color = mdx_get_option( 'mdx_chrome_color' ); ?>
+                    <fieldset>
+                        <label><input type="radio" name="mdx_chrome_color" value="true" <?php if ( $mdx_v_chrome_color == 'true' ){ ?>checked="checked"<?php } ?>> <?php echo $trueon; ?>
+                        </label><br>
+                        <label><input type="radio" name="mdx_chrome_color" value="false" <?php if ( $mdx_v_chrome_color == 'false' ){ ?>checked="checked"<?php } ?>> <?php echo $falseoff; ?>
+                        </label><br>
+                        <p class="description"><?php _e( '开启后，移动 Chrome 访问时，其标题栏的背景颜色会随主题颜色变化。', 'mdx' ); ?></p>
+                    </fieldset>
+                </td>
+            </tr>
+            <tr>
+                <th scope="row"><?php _e( '文章无特色图像时显示默认图像', 'mdx' ); ?></th>
+                <td>
+					<?php $mdx_v_post_def_img = mdx_get_option( 'mdx_post_def_img' ); ?>
+                    <fieldset>
+                        <label><input type="radio" name="mdx_post_def_img" value="true" <?php if ( $mdx_v_post_def_img == 'true' ){ ?>checked="checked"<?php } ?>> <?php echo $trueon; ?>
+                        </label><br>
+                        <label><input type="radio" name="mdx_post_def_img" value="false" <?php if ( $mdx_v_post_def_img == 'false' ){ ?>checked="checked"<?php } ?>> <?php echo $falseoff; ?>
+                        </label><br>
+                        <p class="description"><?php _e( '开启后，文章无特色图像时将显示默认图像，影响文章列表和文章页。若关闭则不显示。', 'mdx' ); ?></p>
+                    </fieldset>
+                </td>
+            </tr>
+            <tr>
+                <th scope="row"><?php _e( '文章默认特色图像', 'mdx' ); ?></th>
+                <td>
+                    <input name="mdx_post_def_img_url" type="text" id="mdx_post_def_img_url" value="<?php echo esc_attr( mdx_get_option( 'mdx_post_def_img_url' ) ) ?>" class="regular-text">
+                    <button type="button" id="insert-media-button-5" class="button" style="margin-top:5px;display:block"><?php _e( '选择图片', 'mdx' ); ?></button>
+                    <p class="description"><?php _e( '指定文章默认特色图像，留空则使用主题内置默认特色图像。', 'mdx' ); ?></p>
+                    <img id="img5" style="width:100%;max-width:300px;height:auto;margin-top:5px;"></img>
+                </td>
+            </tr>
+            </tbody>
+
+            <tbody class="mdx-admin-section" id="mdx-admin-nav-index-section">
+            <tr>
+                <th scope="row"><label for="mdx_index_show"><?php _e( '首页样式', 'mdx' ); ?></label></th>
+                <td>
+					<?php $mdx_v_index_show = mdx_get_option( 'mdx_index_show' ); ?>
+                    <select name="mdx_index_show" id="mdx_index_show">
+                        <option value="0" <?php if ( $mdx_v_index_show == '0' ){ ?>selected="selected"<?php } ?>><?php _e( '默认', 'mdx' ); ?></option>
+                        <option value="1" <?php if ( $mdx_v_index_show == '1' ){ ?>selected="selected"<?php } ?>><?php _e( '简单', 'mdx' ); ?></option>
+                        <option value="2" <?php if ( $mdx_v_index_show == '2' ){ ?>selected="selected"<?php } ?>><?php _e( '两栏', 'mdx' ); ?></option>
+                        <!-- <option value="3" <?php if ( $mdx_v_index_show == '3' ) { ?>selected="selected"<?php } ?>><?php _e( '现代', 'mdx' ); ?></option> -->
+                        <option value="4" <?php if ( $mdx_v_index_show == '4' ){ ?>selected="selected"<?php } ?>><?php _e( '朴素', 'mdx' ); ?></option>
+                    </select>
+                    <div class="mdx-svg-preview" id="mdx-index-preview"></div>
+                </td>
+            </tr>
+            <tr>
+                <th scope="row"><?php _e( '首页图片', 'mdx' ); ?></th>
+                <td>
+                    <input name="mdx_index_img" type="text" id="mdx_index_img" value="<?php echo esc_attr( mdx_get_option( 'mdx_index_img' ) ) ?>" class="regular-text" required="required">
+                    <button type="button" id="insert-media-button" class="button"><?php _e( '选择图片', 'mdx' ); ?></button>
+                    <button type="button" id="use-bing-api" class="button mdx_stbsip8"><?php _e( '使用必应美图', 'mdx' ); ?></button>
+                    <p class="description"><?php _e( '你可以上传或指定你的媒体库中的图片作为首页上方显示的图片。<strong>注意，“简单”和“朴素”首页样式不会显示首页图片。</strong><br>无论你是否使用首页幻灯片，你都需要设定一张首页图片。<br>如使用必应美图，可在括号内指定图片的日期。0为今日图片，-1为明日准备使用的图片，1为昨日的图片，以此类推，最多到前16日。', 'mdx' ); ?></p>
+                    <img id="img1" style="width:100%;max-width:300px;height:auto;margin-top:5px;"></img>
+                </td>
+            </tr>
+            <tr>
+                <th scope="row"><?php _e( '增加首页图片文字对比度', 'mdx' ); ?></th>
+                <td>
+					<?php $mdx_v_index_img_bg = mdx_get_option( 'mdx_index_img_bg' ); ?>
+                    <fieldset>
+                        <label><input type="radio" name="mdx_index_img_bg" value="true" <?php if ( $mdx_v_index_img_bg == 'true' ){ ?>checked="checked"<?php } ?>> <?php echo $trueon; ?>
+                        </label><br>
+                        <label><input type="radio" name="mdx_index_img_bg" value="false" <?php if ( $mdx_v_index_img_bg == 'false' ){ ?>checked="checked"<?php } ?>> <?php echo $falseoff; ?>
+                        </label><br>
+                        <p class="description"><?php _e( '在首页图片中含大面积白色导致首页格言无法看清时启用此选项。在部分首页样式下不生效。', 'mdx' ); ?></p>
+                    </fieldset>
+                </td>
+            </tr>
+            <tr>
+                <th scope="row"><?php _e( '首页头部展示内容', 'mdx' ); ?></th>
+                <td>
+					<?php $mdx_v_index_head_style = mdx_get_option( 'mdx_index_head_style' ); ?>
+                    <fieldset>
+                        <label><input class="mdx-index-head-style-input" type="radio" name="mdx_index_head_style" value="saying" <?php if ( $mdx_v_index_head_style == 'saying' ){ ?>checked="checked"<?php } ?>> <?php _e( '格言', 'mdx' ); ?>
+                        </label><br>
+                        <label><input class="mdx-index-head-style-input" type="radio" name="mdx_index_head_style" value="slide" <?php if ( $mdx_v_index_head_style == 'slide' ){ ?>checked="checked"<?php } ?>> <?php _e( '幻灯片', 'mdx' ); ?>
+                        </label><br>
+                        <p class="description"><?php _e( '指定首页头部展示的内容。在下方进行详细设置。', 'mdx' ); ?></p>
+                    </fieldset>
+                </td>
+            </tr>
+            <tr class="mdx_index_head_style_saying">
+                <th scope="row"><?php _e( '首页格言', 'mdx' ); ?></th>
+                <td>
+                    <input name="mdx_index_say" type="text" id="mdx_index_say" value="<?php echo esc_attr( mdx_get_option( 'mdx_index_say' ) ) ?>" class="regular-text mdx_index_head_style">
+                    <p class="description"><?php _e( '这句话会展示在首页。', 'mdx' ); ?></p>
+                </td>
+            </tr>
+            <tr class="mdx_index_head_style_saying">
+                <th scope="row"><label for="mdx_index_say_size"><?php _e( '首页格言字体大小', 'mdx' ); ?></label></th>
+                <td>
+					<?php $mdx_v_index_say_size = mdx_get_option( 'mdx_index_say_size' ); ?>
+                    <select name="mdx_index_say_size" id="mdx_index_say_size">
+                        <option value="1" <?php if ( $mdx_v_index_say_size == '1' ){ ?>selected="selected"<?php } ?>>H1</option>
+                        <option value="2" <?php if ( $mdx_v_index_say_size == '2' ){ ?>selected="selected"<?php } ?>>H2</option>
+                        <option value="3" <?php if ( $mdx_v_index_say_size == '3' ){ ?>selected="selected"<?php } ?>>H3</option>
+                        <option value="4" <?php if ( $mdx_v_index_say_size == '4' ){ ?>selected="selected"<?php } ?>>H4</option>
+                        <option value="5" <?php if ( $mdx_v_index_say_size == '5' ){ ?>selected="selected"<?php } ?>>H5</option>
+                        <option value="6" <?php if ( $mdx_v_index_say_size == '6' ){ ?>selected="selected"<?php } ?>>H6</option>
+                    </select>
+                    <p class="description"><?php _e( '字体大小由 H1 至 H6 依次变小。在部分首页样式中无效。', 'mdx' ); ?></p>
+                </td>
+            </tr>
+            <tr class="mdx_index_head_style_slide">
+                <th scope="row"><label for="mdx_index_slide_posts_style"><?php _e( '首页幻灯片样式', 'mdx' ); ?></label></th>
+                <td>
+					<?php $mdx_v_index_slide_posts_style = mdx_get_option( 'mdx_index_slide_posts_style' ); ?>
+                    <select name="mdx_index_slide_posts_style" id="mdx_index_slide_posts_style">
+                        <option value="1" <?php if ( $mdx_v_index_slide_posts_style == '1' ){ ?>selected="selected"<?php } ?>><?php _e( '居中', 'mdx' ); ?></option>
+                        <option value="2" <?php if ( $mdx_v_index_slide_posts_style == '2' ){ ?>selected="selected"<?php } ?>><?php _e( '现代', 'mdx' ); ?></option>
+                        <option value="3" <?php if ( $mdx_v_index_slide_posts_style == '3' ){ ?>selected="selected"<?php } ?>><?php _e( '朴素', 'mdx' ); ?></option>
+                        <option value="4" <?php if ( $mdx_v_index_slide_posts_style == '4' ){ ?>selected="selected"<?php } ?>><?php _e( '纯色', 'mdx' ); ?></option>
+                    </select>
+                </td>
+            </tr>
+            <tr class="mdx_index_head_style_slide">
+                <th scope="row"><label for="mdx_index_slide_posts_num"><?php _e( '首页幻灯片文章数量', 'mdx' ); ?></label></th>
+                <td>
+                    <input name="mdx_index_slide_posts_num" type="number" min="1" id="mdx_index_slide_posts_num" value="<?php echo esc_attr( mdx_get_option( 'mdx_index_slide_posts_num' ) ) ?>" class="regular-text">
+                    <p class="description"><?php _e( '在此设定首页幻灯片文章篇数。请输入整数。', 'mdx' ); ?></p></td>
+            </tr>
+            <tr class="mdx_index_head_style_slide">
+                <th scope="row"><label for="mdx_index_slide_interval"><?php _e( '首页幻灯片自动切换时间', 'mdx' ); ?></label></th>
+                <td>
+                    <input name="mdx_index_slide_interval" type="number" min="1" id="mdx_index_slide_interval" value="<?php echo esc_attr( mdx_get_option( 'mdx_index_slide_interval' ) ) ?>" class="regular-text">
+                    <p class="description"><?php _e( '单位为秒。请输入整数。', 'mdx' ); ?></p></td>
+            </tr>
+            <tr class="mdx_index_head_style_slide">
+                <th scope="row"><?php _e( '首页幻灯片文章获取方式', 'mdx' ); ?></th>
+                <td>
+					<?php $mdx_v_index_slide_posts_get = mdx_get_option( 'mdx_index_slide_posts_get' ); ?>
+                    <fieldset>
+                        <label><input type="radio" class="mdx_index_get" name="mdx_index_slide_posts_get" value="cat" <?php if ( $mdx_v_index_slide_posts_get == 'cat' ){ ?>checked="checked"<?php } ?>> <?php _e( '某一分类', 'mdx' ); ?>
+                        </label><br>
+                        <label><input type="radio" class="mdx_index_get" name="mdx_index_slide_posts_get" value="sticky" <?php if ( $mdx_v_index_slide_posts_get == 'sticky' ){ ?>checked="checked"<?php } ?>> <?php _e( '置顶文章', 'mdx' ); ?>
+                        </label><br>
+                        <p class="description"><?php _e( '在此设定首页幻灯片文章的获取方式。<br>若选择置顶文章，当没有置顶文章时，将会显示首页图片，同时文章列表将保持原始顺序而不会被置顶文章打乱。', 'mdx' ); ?></p>
+                    </fieldset>
+                </td>
+            </tr>
+            <tr class="mdx_index_head_style_slide">
+                <th scope="row"><label for="mdx_index_slide_posts_cat"><?php _e( '首页幻灯片文章分类名', 'mdx' ); ?></label></th>
+                <td>
+                    <input name="mdx_index_slide_posts_cat" type="text" id="mdx_index_slide_posts_cat" value="<?php echo esc_attr( mdx_get_option( 'mdx_index_slide_posts_cat' ) ) ?>" class="regular-text">
+                    <p class="description"><?php _e( '在此设定首页幻灯片文章的分类名。当分类不存在时，将显示最新文章。', 'mdx' ); ?></p></td>
+            </tr>
+            </tbody>
+
+            <tbody class="mdx-admin-section" id="mdx-admin-nav-post-section">
+            <tr>
+                <th scope="row"><label for="mdx_post_style"><?php _e( '文章页样式', 'mdx' ); ?></label></th>
+                <td>
+					<?php $mdx_v_post_style = mdx_get_option( 'mdx_post_style' ); ?>
+                    <select name="mdx_post_style" id="mdx_post_style">
+                        <option value="0" <?php if ( $mdx_v_post_style == '0' ){ ?>selected="selected"<?php } ?>><?php _e( '标准', 'mdx' ); ?></option>
+                        <option value="1" <?php if ( $mdx_v_post_style == '1' ){ ?>selected="selected"<?php } ?>><?php _e( '简洁', 'mdx' ); ?></option>
+                        <option value="2" <?php if ( $mdx_v_post_style == '2' ){ ?>selected="selected"<?php } ?>><?php _e( '通透', 'mdx' ); ?></option>
+                        <option value="3" <?php if ( $mdx_v_post_style == '3' ){ ?>selected="selected"<?php } ?>><?php _e( '朴素', 'mdx' ); ?></option>
+                    </select>
+                    <div class="mdx-svg-preview" id="mdx-post-preview"></div>
+                    <p class="description"><?php _e( '同时影响文章页、单独页面的样式。', 'mdx' ); ?></p>
+                </td>
+            </tr>
+            <tr>
+                <th scope="row"><label for="mdx_post_time_positon"><?php _e( '文章时间显示位置', 'mdx' ); ?></label></th>
+                <td>
+					<?php $mdx_v_post_time_positon = mdx_get_option( 'mdx_post_time_positon' ); ?>
+                    <select name="mdx_post_time_positon" id="mdx_post_time_positon">
+                        <option value="title" <?php if ( $mdx_v_post_time_positon == 'title' ){ ?>selected="selected"<?php } ?>><?php _e( '标题旁', 'mdx' ); ?></option>
+                        <option value="foot" <?php if ( $mdx_v_post_time_positon == 'foot' ){ ?>selected="selected"<?php } ?>><?php _e( '文章末尾', 'mdx' ); ?></option>
+                        <option value="none" <?php if ( $mdx_v_post_time_positon == 'none' ){ ?>selected="selected"<?php } ?>><?php _e( '不显示', 'mdx' ); ?></option>
+                    </select>
+                </td>
+            </tr>
+            <tr>
+                <th scope="row"><label for="mdx_post_nav_style"><?php _e( '文章导航栏配色方案', 'mdx' ); ?></label></th>
+                <td>
+					<?php $mdx_v_post_nav_style = mdx_get_option( 'mdx_post_nav_style' ); ?>
+                    <select name="mdx_post_nav_style" id="mdx_post_nav_style">
+                        <option value="0" <?php if ( $mdx_v_post_nav_style == '0' ){ ?>selected="selected"<?php } ?>><?php _e( '主题色', 'mdx' ); ?></option>
+                        <option value="1" <?php if ( $mdx_v_post_nav_style == '1' ){ ?>selected="selected"<?php } ?>><?php _e( '低饱和度', 'mdx' ); ?></option>
+                    </select>
+                    <p class="description"><?php _e( '影响文章末尾文章导航栏区域的配色。', 'mdx' ); ?></p>
+                </td>
+            </tr>
+            <tr>
+                <th scope="row"><label for="mdx_say_after"><?php _e( '文末信息', 'mdx' ); ?></label></th>
+                <td>
+                    <textarea name="mdx_say_after" id="mdx_say_after" rows="7" cols="50"><?php echo mdx_get_option( 'mdx_say_after' ) ?></textarea>
+                    <p class="description"><?php _e( '在这里编辑文末信息。文末信息会显示在每篇文章的底部，留空则不会显示。支持 <code>HTML</code> 格式。<code>--PostLink--</code> 会被替换为链接到当前文章的文章标题，<code>--PostURL--</code> 会被替换为链接到当前文章的当前文章 URL（大小写敏感）。', 'mdx' ); ?></p>
+                </td>
+            </tr>
+            </tbody>
+
+            <tbody class="mdx-admin-section" id="mdx-admin-nav-post-list-section">
+            <tr>
+                <th scope="row"><label for="mdx_default_style"><?php _e( '文章列表样式', 'mdx' ); ?></label></th>
+                <td>
+					<?php $mdx_v_default_style = mdx_get_option( 'mdx_default_style' ); ?>
+                    <select name="mdx_default_style" id="mdx_default_style">
+                        <option value="1" <?php if ( $mdx_v_default_style == '1' ){ ?>selected="selected"<?php } ?>><?php _e( '简洁', 'mdx' ); ?></option>
+                        <option value="2" <?php if ( $mdx_v_default_style == '2' ){ ?>selected="selected"<?php } ?>><?php _e( '列表', 'mdx' ); ?></option>
+                        <option value="3" <?php if ( $mdx_v_default_style == '3' ){ ?>selected="selected"<?php } ?>><?php _e( '干净', 'mdx' ); ?></option>
+                        <option value="4" <?php if ( $mdx_v_default_style == '4' ){ ?>selected="selected"<?php } ?>><?php _e( '网格', 'mdx' ); ?></option>
+                        <option value="5" <?php if ( $mdx_v_default_style == '5' ){ ?>selected="selected"<?php } ?>><?php _e( '朴素', 'mdx' ); ?></option>
+                        <!-- <option value="6" <?php if ( $mdx_v_default_style == '6' ) { ?>selected="selected"<?php } ?>><?php _e( '现代', 'mdx' ); ?></option> -->
+                    </select>
+                    <div class="mdx-svg-preview" id="mdx-list-preview"></div>
+                    <p class="description"><?php _e( '同时影响首页、搜索结果页、归档页的文章列表样式。', 'mdx' ); ?></p>
+                </td>
+            </tr>
+            <tr>
+                <th scope="row"><?php _e( '文章列表宽度', 'mdx' ); ?></th>
+                <td>
+					<?php $mdx_v_post_list_width = mdx_get_option( 'mdx_post_list_width' ); ?>
+                    <fieldset>
+                        <label><input type="radio" name="mdx_post_list_width" value="normal" <?php if ( $mdx_v_post_list_width == 'normal' ){ ?>checked="checked"<?php } ?>> <?php _e( '正常', 'mdx' ); ?>
+                        </label><br>
+                        <label><input type="radio" name="mdx_post_list_width" value="wide" <?php if ( $mdx_v_post_list_width == 'wide' ){ ?>checked="checked"<?php } ?>> <?php _e( '较宽', 'mdx' ); ?>
+                        </label><br>
+                    </fieldset>
+                    <p class="description"><?php _e( '使用“较宽”，文章列表将会以多列瀑布流显示。', 'mdx' ); ?></p>
+                </td>
+            </tr>
+            <tr>
+                <th scope="row"><?php _e( '文章列表显示文章摘要', 'mdx' ); ?></th>
+                <td>
+					<?php $mdx_v_echo_post_sum = mdx_get_option( 'mdx_echo_post_sum' ); ?>
+                    <fieldset>
+                        <label><input type="radio" name="mdx_echo_post_sum" value="true" <?php if ( $mdx_v_echo_post_sum == 'true' ){ ?>checked="checked"<?php } ?>> <?php echo $trueon; ?>
+                        </label><br>
+                        <label><input type="radio" name="mdx_echo_post_sum" value="false" <?php if ( $mdx_v_echo_post_sum == 'false' ){ ?>checked="checked"<?php } ?>> <?php echo $falseoff; ?>
+                        </label><br>
+                        <p class="description"><?php _e( '开启后，文章列表可显示每篇文章的摘要，影响首页和归档页。若关闭则不显示。', 'mdx' ); ?></p>
+                    </fieldset>
+                </td>
+            </tr>
+            <tr>
+                <th scope="row"><label for="mdx_post_list_img_height"><?php _e( '文章列表图片高度', 'mdx' ); ?></label></th>
+                <td>
+					<?php $mdx_v_post_list_img_height = mdx_get_option( 'mdx_post_list_img_height' ); ?>
+                    <select name="mdx_post_list_img_height" id="mdx_post_list_img_height">
+                        <option value="auto" <?php if ( $mdx_v_post_list_img_height == 'auto' ){ ?>selected="selected"<?php } ?>><?php _e( '自适应', 'mdx' ); ?></option>
+                        <option value="fixed" <?php if ( $mdx_v_post_list_img_height == 'fixed' ){ ?>selected="selected"<?php } ?>><?php _e( '固定宽高比', 'mdx' ); ?></option>
+                    </select>
+                    <p class="description"><?php _e( '选择 <code>自适应</code>，文章特色图像可以完全展示。<br>选择 <code>固定宽高比</code>，文章特色图像可能会只显示部分以保持宽高比，但图像不会被拉伸，适合于图像过宽/过高的情况。', 'mdx' ); ?></p>
+                </td>
+            </tr>
+            </tbody>
+
+            <tbody class="mdx-admin-section" id="mdx-admin-nav-title-bar-section">
+            <tr>
+                <th scope="row"><?php _e( '自动隐藏标题栏', 'mdx' ); ?></th>
+                <td>
+					<?php $mdx_v_title_bar = mdx_get_option( 'mdx_title_bar' ); ?>
+                    <fieldset>
+                        <label><input type="radio" name="mdx_title_bar" value="true" <?php if ( $mdx_v_title_bar == 'true' ){ ?>checked="checked"<?php } ?>> <?php echo $trueon; ?>
+                        </label><br>
+                        <label><input type="radio" name="mdx_title_bar" value="false" <?php if ( $mdx_v_title_bar == 'false' ){ ?>checked="checked"<?php } ?>> <?php echo $falseoff; ?>
+                        </label><br>
+                        <p class="description"><?php _e( '开启后，页面向下滚动时标题栏会向上隐藏，向上滚动时会出现。', 'mdx' ); ?></p>
+                    </fieldset>
+                </td>
+            </tr>
+            <tr>
+                <th scope="row"><label for="mdx_logo_way"><?php _e( '标题栏显示内容', 'mdx' ); ?></label></th>
+                <td>
+					<?php $mdx_v_logo_way = mdx_get_option( 'mdx_logo_way' ); ?>
+                    <select name="mdx_logo_way" id="mdx_logo_way" onchange="mdx_logo_sec(this.options[this.options.selectedIndex].value)">
+                        <option value="1" <?php if ( $mdx_v_logo_way == '1' ){ ?>selected="selected"<?php } ?>><?php _e( '博客名称', 'mdx' ); ?></option>
+                        <option value="2" <?php if ( $mdx_v_logo_way == '2' ){ ?>selected="selected"<?php } ?>><?php _e( '自定义 Logo', 'mdx' ); ?></option>
+                        <option value="3" <?php if ( $mdx_v_logo_way == '3' ){ ?>selected="selected"<?php } ?>><?php _e( '自定义名称', 'mdx' ); ?></option>
+                    </select>
+                </td>
+            </tr>
+            <tr class="logo_logo">
+                <th scope="row"><?php _e( '标题栏 Logo', 'mdx' ); ?></th>
+                <td>
+                    <input name="mdx_logo" type="url" id="mdx_logo" value="<?php echo esc_attr( mdx_get_option( 'mdx_logo' ) ) ?>" class="regular-text">
+                    <button type="button" id="insert-media-button-2" class="button"><?php _e( '选择图片', 'mdx' ); ?></button>
+                    <p class="description"><?php _e( '选择一张图片作为网站 Logo。', 'mdx' ); ?></p>
+                    <img id="img4" style="width:100%;max-width:300px;height:auto;margin-top:5px;"></img>
+                </td>
+            </tr>
+            <tr class="logo_text">
+                <th scope="row"><?php _e( '标题栏自定义名称', 'mdx' ); ?></th>
+                <td>
+                    <input name="mdx_logo_text" type="text" id="mdx_logo_text" value="<?php echo esc_attr( mdx_get_option( 'mdx_logo_text' ) ) ?>" class="regular-text">
+                </td>
+            </tr>
+            <tr>
+                <th scope="row"><?php _e( '点击标题栏返回顶部', 'mdx' ); ?></th>
+                <td>
+					<?php $mdx_v_tap_to_top = mdx_get_option( 'mdx_tap_to_top' ); ?>
+                    <fieldset>
+                        <label><input type="radio" name="mdx_tap_to_top" value="true" <?php if ( $mdx_v_tap_to_top == 'true' ){ ?>checked="checked"<?php } ?>> <?php echo $trueon; ?>
+                        </label><br>
+                        <label><input type="radio" name="mdx_tap_to_top" value="false" <?php if ( $mdx_v_tap_to_top == 'false' ){ ?>checked="checked"<?php } ?>> <?php echo $falseoff; ?>
+                        </label><br>
+                        <p class="description"><?php _e( '开启后，点击标题栏可以返回页面顶部。此设置影响所有页面。', 'mdx' ); ?></p>
+                    </fieldset>
+                </td>
+            </tr>
+            </tbody>
+
+            <tbody class="mdx-admin-section" id="mdx-admin-nav-drawer-section">
+            <tr>
+                <th scope="row"><?php _e( '抽屉菜单顶部展示个人信息', 'mdx' ); ?></th>
+                <td>
+					<?php $mdx_v_side_info = mdx_get_option( 'mdx_side_info' ); ?>
+                    <fieldset>
+                        <label><input class="mdx_stbs2" type="radio" name="mdx_side_info" value="true" <?php if ( $mdx_v_side_info == 'true' ){ ?>checked="checked"<?php } ?>> <?php echo $trueon; ?>
+                        </label><br>
+                        <label><input class="mdx_stbs2" type="radio" name="mdx_side_info" value="false" <?php if ( $mdx_v_side_info == 'false' ){ ?>checked="checked"<?php } ?>> <?php echo $falseoff; ?>
+                        </label><br>
+                        <p class="description"><?php _e( '开启后，抽屉顶部会显示头像及名称，请在下方设置。', 'mdx' ); ?></p>
+                    </fieldset>
+                </td>
+            </tr>
+            <tr>
+                <th scope="row"><?php _e( '抽屉菜单顶部图片', 'mdx' ); ?></th>
+                <td>
+                    <input name="mdx_side_img" type="url" id="mdx_side_img" value="<?php echo esc_attr( mdx_get_option( 'mdx_side_img' ) ) ?>" class="regular-text mdx_stbsip2">
+                    <button type="button" id="insert-media-button-3" class="button mdx_stbsip22"><?php _e( '选择图片', 'mdx' ); ?></button>
+                    <img id="img2" style="width:100%;max-width:300px;height:auto;margin-top:5px;"></img>
+                </td>
+            </tr>
+            <tr>
+                <th scope="row"><?php _e( '抽屉菜单信息头像', 'mdx' ); ?></th>
+                <td>
+                    <input name="mdx_side_head" type="url" id="mdx_side_head" value="<?php echo esc_attr( mdx_get_option( 'mdx_side_head' ) ) ?>" class="regular-text mdx_stbsip22">
+                    <button type="button" id="insert-media-button-4" class="button mdx_stbsip1 mdx_stbsip22"><?php _e( '选择图片', 'mdx' ); ?></button>
+                    <p class="description"><?php _e( '选择一张图片作为抽屉顶部显示的头像。留空则不显示。', 'mdx' ); ?></p>
+                    <img id="img3" style="width:100%;max-width:300px;height:auto;margin-top:5px;;margin-top:5px;"></img>
+                </td>
+            </tr>
+            <tr>
+                <th scope="row"><?php _e( '抽屉菜单信息名称', 'mdx' ); ?></th>
+                <td>
+                    <input name="mdx_side_name" type="text" id="mdx_side_name" value="<?php echo esc_attr( mdx_get_option( 'mdx_side_name' ) ) ?>" class="regular-text mdx_stbsip2" required="required">
+                </td>
+            </tr>
+            <tr>
+                <th scope="row"><?php _e( '抽屉菜单详细信息', 'mdx' ); ?></th>
+                <td>
+                    <input name="mdx_side_more" type="text" id="mdx_side_more" value="<?php echo esc_attr( mdx_get_option( 'mdx_side_more' ) ) ?>" class="regular-text mdx_stbsip2" required="required">
+                    <p class="description"><?php _e( '这里的内容会显示在抽屉菜单信息名称的下方。', 'mdx' ); ?></p>
+                </td>
+            </tr>
+            </tbody>
+
+            <tbody class="mdx-admin-section" id="mdx-admin-nav-footer-section">
+            <tr>
+                <th scope="row"><label for="mdx_styles_footer"><?php _e( '页脚样式', 'mdx' ); ?></label></th>
+                <td>
+					<?php $mdx_v_styles_footer = mdx_get_option( 'mdx_styles_footer' ); ?>
+                    <select name="mdx_styles_footer" id="mdx_styles_footer">
+                        <option value="1" <?php if ( $mdx_v_styles_footer == '1' ){ ?>selected="selected"<?php } ?>><?php _e( '传统', 'mdx' ); ?></option>
+                        <option value="2" <?php if ( $mdx_v_styles_footer == '2' ){ ?>selected="selected"<?php } ?>><?php _e( '简单', 'mdx' ); ?></option>
+                        <option value="3" <?php if ( $mdx_v_styles_footer == '3' ){ ?>selected="selected"<?php } ?>><?php _e( '现代', 'mdx' ); ?></option>
+                    </select>
+                    <p class="description"><?php _e( '在此设定页脚样式。<strong>如果选择“简单”样式，那么页脚格言将不会显示。</strong>', 'mdx' ); ?></p>
+                </td>
+            </tr>
+            <tr>
+                <th scope="row"><label for="mdx_footer_say"><?php _e( '页脚格言', 'mdx' ); ?></label></th>
+                <td>
+                    <input class="regular-text" name="mdx_footer_say" type="text" id="mdx_footer_say" value="<?php echo esc_attr( mdx_get_option( 'mdx_footer_say' ) ) ?>">
+                    <button type="button" id="use-api" class="button mdx_stbsip7"><?php _e( '使用一言 API（常规）', 'mdx' ); ?></button>
+                    <button type="button" id="use-api2" class="button mdx_stbsip7"><?php _e( '使用一言 API（古诗词）', 'mdx' ); ?></button>
+                    <button type="button" id="use-api3" class="button mdx_stbsip7"><?php _e( '使用一言 API（自定义）', 'mdx' ); ?></button>
+                    <p class="description" id="mdx_footer"><?php _e( '这句话会显示在每个页面的页脚，如果不希望显示，请留空。若调用一言 API，则每次页面刷新后都会显示不同的格言。此 API 来自第三方，请注意安全风险。', 'mdx' ); ?></p>
+                    <p class="description" id="mdx_custom_api"><?php _e( '如使用自定义 API，你需要在括号内填写 API URL 并确保 API 返回 <code>{"text":"句子"}</code> 的 JSON 格式。<a href="https://doc.flyhigher.top/mdx/zh-CN/config/custom_api/" target="_blank">详细信息</a></code>', 'mdx' ); ?></p>
+                </td>
+            </tr>
+            <tr>
+                <th scope="row"><label for="mdx_footer"><?php _e( '页脚内容', 'mdx' ); ?></label></th>
+                <td>
+                    <textarea name="mdx_footer" id="mdx_footer" rows="7" cols="50"><?php echo mdx_get_option( 'mdx_footer' ) ?></textarea><br><a class="thickbox button" title="<?php _e( '社交网站图标编辑器', 'mdx' ); ?>" href="#TB_inline?height=100%&width=100%&inlineId=social-network-editor" style="margin-top: 5px;"><?php _e( '社交网站图标编辑器', 'mdx' ); ?></a>
+                    <p class="description"><?php _e( '在这里编辑页脚内容。支持 <code>HTML</code> 格式。', 'mdx' ); ?></p></td>
+            </tr>
+            </tbody>
+
+            <tbody class="mdx-admin-section" id="mdx-admin-nav-touch-bar-icon-section">
+            <tr>
+                <th scope="row"><?php _e( 'Safari Touch Bar 图标支持', 'mdx' ); ?></th>
+                <td>
+					<?php $mdx_v_safari = mdx_get_option( 'mdx_safari' ); ?>
+                    <fieldset>
+                        <label><input class="mdx_stbs" type="radio" name="mdx_safari" value="true" <?php if ( $mdx_v_safari == 'true' ){ ?>checked="checked"<?php } ?>> <?php echo $trueon; ?>
+                        </label><br>
+                        <label><input class="mdx_stbs" type="radio" name="mdx_safari" value="false" <?php if ( $mdx_v_safari == 'false' ){ ?>checked="checked"<?php } ?>> <?php echo $falseoff; ?>
+                        </label><br>
+                    </fieldset>
+                    <p class="description"><?php _e( '开启后会启用对 Safari Touch Bar 图标的支持，请在下方完成相关设置。<a href="https://developer.apple.com/library/content/documentation/AppleApplications/Reference/SafariWebContent/pinnedTabs/pinnedTabs.html" target="_blank">详细了解</a>', 'mdx' ); ?>
+                </td>
+            </tr>
+            <tr>
+                <th scope="row"><label for="mdx_svg"><?php _e( 'Touch Bar 图标地址', 'mdx' ); ?></label></th>
+                <td>
+                    <input class="mdx_stbsip regular-text mdx_stbsip3" name="mdx_svg" type="text" id="mdx_svg" value="<?php echo esc_attr( mdx_get_option( 'mdx_svg' ) ) ?>" required="required">
+                    <p class="description" id="mdx_footer"><?php _e( '请设置 Touch Bar 图标地址。格式为 SVG，必须为单层，viewbox 属性必须为"0 0 16 16"。', 'mdx' ); ?></p>
+                </td>
+            </tr>
+            <tr>
+                <th scope="row"><label for="mdx_svg_color"><?php _e( 'Touch Bar 图标背景颜色', 'mdx' ); ?></label></th>
+                <td>
+                    <input class="mdx_stbsip regular-text mdx_stbsip3" name="mdx_svg_color" type="text" id="mdx_svg_color" value="<?php echo esc_attr( mdx_get_option( 'mdx_svg_color' ) ) ?>" required="required"><br>
+                    <a id="change-color" class="button mdx_stbsip5" href="javascript:jQuery('#mdx_svg_color').val('<?php echo mdx_get_option( 'mdx_styles_hex' ); ?>');jQuery('#mdx_svg_color').wpColorPicker('color', '<?php echo mdx_get_option( 'mdx_styles_hex' ); ?>');"><?php _e( '使用当前主题颜色', 'mdx' ); ?></a>
+                    <p class="description" id="mdx_footer"><?php _e( '请设置 Touch Bar 图标背景颜色。16 进制颜色或 RGB 颜色。', 'mdx' ); ?></p>
+                </td>
+            </tr>
+            </tbody>
+
+            <tbody class="mdx-admin-section" id="mdx-admin-nav-others-section">
+            <tr>
+                <th scope="row"><?php _e( '登录页 Material Design', 'mdx' ); ?></th>
+                <td>
+					<?php $mdx_v_login_md = mdx_get_option( 'mdx_login_md' ); ?>
+                    <fieldset>
+                        <label><input type="radio" name="mdx_login_md" value="true" <?php if ( $mdx_v_login_md == 'true' ){ ?>checked="checked"<?php } ?>> <?php echo $trueon; ?>
+                        </label><br>
+                        <label><input type="radio" name="mdx_login_md" value="false" <?php if ( $mdx_v_login_md == 'false' ){ ?>checked="checked"<?php } ?>> <?php echo $falseoff; ?>
+                        </label><br>
+                        <p class="description"><?php _e( '将 Material Design 样式应用到登录页。可能与部分插件样式不兼容。', 'mdx' ); ?></p>
+                    </fieldset>
+                </td>
+            </tr>
+            <tr>
+                <th scope="row"><?php _e( '启用友链 Gravatar 支持', 'mdx' ); ?></th>
+                <td>
+					<?php $mdx_v_gravatar_actived = mdx_get_option( 'mdx_gravatar_actived' ); ?>
+                    <fieldset>
+                        <label><input type="radio" name="mdx_gravatar_actived" value="true" <?php if ( $mdx_v_gravatar_actived == 'true' ){ ?>checked="checked"<?php } ?>> <?php echo $trueon; ?>
+                        </label><br>
+                        <label><input type="radio" name="mdx_gravatar_actived" value="false" <?php if ( $mdx_v_gravatar_actived == 'false' ){ ?>checked="checked"<?php } ?>> <?php echo $falseoff; ?>
+                        </label><br>
+                        <p class="description"><?php _e( '开启后，将尝试从备注栏中获取邮箱并将与邮箱对应的 Gravatar 头像作为友情链接图像。关闭则只使用图片链接。', 'mdx' ); ?></p>
+                    </fieldset>
+                </td>
+            </tr>
+            <tr>
+                <th scope="row"><?php _e( '友情链接随机顺序', 'mdx' ); ?></th>
+                <td>
+					<?php $mdx_v_link_rand_order = mdx_get_option( 'mdx_link_rand_order' ); ?>
+                    <fieldset>
+                        <label><input type="radio" name="mdx_link_rand_order" value="true" <?php if ( $mdx_v_link_rand_order == 'true' ){ ?>checked="checked"<?php } ?>> <?php echo $trueon; ?>
+                        </label><br>
+                        <label><input type="radio" name="mdx_link_rand_order" value="false" <?php if ( $mdx_v_link_rand_order == 'false' ){ ?>checked="checked"<?php } ?>> <?php echo $falseoff; ?>
+                        </label><br>
+                        <p class="description"><?php _e( '开启后，友情链接将以随机顺序显示。关闭则使用字典序。', 'mdx' ); ?></p>
+                    </fieldset>
+                </td>
+            </tr>
+            <tr>
+                <th scope="row"><label for="mdx_title_med"><?php _e( '网页标题计算方式', 'mdx' ); ?></label></th>
+                <td>
+					<?php $mdx_v_title_med = mdx_get_option( 'mdx_title_med' ); ?>
+                    <select name="mdx_title_med" id="mdx_title_med">
+                        <option value="wp" <?php if ( $mdx_v_title_med == 'wp' ){ ?>selected="selected"<?php } ?>><?php _e( 'WordPress 默认', 'mdx' ); ?></option>
+                        <option value="diy" <?php if ( $mdx_v_title_med == 'diy' ){ ?>selected="selected"<?php } ?>><?php _e( 'MDx 优化', 'mdx' ); ?></option>
+                    </select>
+                    <p class="description"><?php _e( '选择 <code>WordPress 默认</code>，WordPress 会接管网页标题的内容，此方式兼容大部分 SEO 插件。<br>选择 <code>MDx 优化</code>，MDx 会接管网页标题的内容，此方式在部分情况下更合适，但不兼容 SEO 插件。', 'mdx' ); ?></p>
+                </td>
+            </tr>
+            <tr>
+                <th scope="row"><?php _e( '多彩标签云', 'mdx' ); ?></th>
+                <td>
+					<?php $mdx_v_tags_color = mdx_get_option( 'mdx_tags_color' ); ?>
+                    <fieldset>
+                        <label><input type="radio" name="mdx_tags_color" value="true" <?php if ( $mdx_v_tags_color == 'true' ){ ?>checked="checked"<?php } ?>> <?php echo $trueon; ?>
+                        </label><br>
+                        <label><input type="radio" name="mdx_tags_color" value="false" <?php if ( $mdx_v_tags_color == 'false' ){ ?>checked="checked"<?php } ?>> <?php echo $falseoff; ?>
+                        </label><br>
+                        <p class="description"><?php _e( '开启后，标签云页面输出的标签会带有随机颜色，反之为同一颜色。', 'mdx' ); ?></p>
+                    </fieldset>
+                </td>
+            </tr>
+            </tbody>
+        </table>
+        <div id="social-network-editor" style="display:none;">
+            <br>
+            <p class="description"><?php _e( '在这里获取受 MDx 样式支持的社交网站图标链接。填写完成之后，你可以将获取到的代码粘贴到包括页脚内容在内的任何地方或是自定义代码内容。未填写的项目将被忽略。', 'mdx' ); ?></p>
+            <table class="form-table">
+                <tr>
+                    <th scope="row"><label for="mdx_sn_qq"><?php _e( 'QQ', 'mdx' ); ?></label></th>
+                    <td>
+                        <input class="regular-text" name="mdx_sn_qq" type="text" id="mdx_sn_qq" value="" placeholder="<?php _e( 'QQ 号', 'mdx' ); ?>" oninput="input_onchange()" data-alt="<?php _e( 'QQ', 'mdx' ); ?>">
+                    </td>
+                </tr>
+                <tr>
+                    <th scope="row"><label for="mdx_sn_wechat"><?php _e( '微信', 'mdx' ); ?></label></th>
+                    <td>
+                        <input class="regular-text" name="mdx_sn_wechat" type="text" id="mdx_sn_wechat" value="" placeholder="<?php _e( '微信二维码图片链接', 'mdx' ); ?>" oninput="input_onchange()" data-alt="<?php _e( '微信', 'mdx' ); ?>">
+                    </td>
+                </tr>
+                <tr>
+                    <th scope="row"><label for="mdx_sn_weibo"><?php _e( '微博', 'mdx' ); ?></label></th>
+                    <td>
+                        <input class="regular-text" name="mdx_sn_weibo" type="text" id="mdx_sn_weibo" value="" placeholder="<?php _e( '微博链接', 'mdx' ); ?>" oninput="input_onchange()" data-alt="<?php _e( '微博', 'mdx' ); ?>">
+                    </td>
+                </tr>
+                <tr>
+                    <th scope="row"><label for="mdx_sn_zhihu"><?php _e( '知乎', 'mdx' ); ?></label></th>
+                    <td>
+                        <input class="regular-text" name="mdx_sn_zhihu" type="text" id="mdx_sn_zhihu" value="" placeholder="<?php _e( '知乎链接', 'mdx' ); ?>" oninput="input_onchange()" data-alt="<?php _e( '知乎', 'mdx' ); ?>">
+                    </td>
+                </tr>
+                <tr>
+                    <th scope="row"><label for="mdx_sn_bilibili"><?php _e( '哔哩哔哩', 'mdx' ); ?></label></th>
+                    <td>
+                        <input class="regular-text" name="mdx_sn_bilibili" type="text" id="mdx_sn_bilibili" value="" placeholder="<?php _e( '哔哩哔哩链接', 'mdx' ); ?>" oninput="input_onchange()" data-alt="<?php _e( '哔哩哔哩', 'mdx' ); ?>">
+                    </td>
+                </tr>
+                <tr>
+                    <th scope="row"><label for="mdx_sn_neteasemusic"><?php _e( '网易云音乐', 'mdx' ); ?></label></th>
+                    <td>
+                        <input class="regular-text" name="mdx_sn_neteasemusic" type="text" id="mdx_sn_neteasemusic" value="" placeholder="<?php _e( '网易云音乐链接', 'mdx' ); ?>" oninput="input_onchange()" data-alt="<?php _e( '网易云音乐', 'mdx' ); ?>">
+                    </td>
+                </tr>
+                <tr>
+                    <th scope="row"><label for="mdx_sn_coolapk"><?php _e( '酷安', 'mdx' ); ?></label></th>
+                    <td>
+                        <input class="regular-text" name="mdx_sn_coolapk" type="text" id="mdx_sn_coolapk" value="" placeholder="<?php _e( '酷安链接', 'mdx' ); ?>" oninput="input_onchange()" data-alt="<?php _e( '酷安', 'mdx' ); ?>">
+                    </td>
+                </tr>
+                <tr>
+                    <th scope="row"><label for="mdx_sn_douban"><?php _e( '豆瓣', 'mdx' ); ?></label></th>
+                    <td>
+                        <input class="regular-text" name="mdx_sn_douban" type="text" id="mdx_sn_douban" value="" placeholder="<?php _e( '豆瓣链接', 'mdx' ); ?>" oninput="input_onchange()" data-alt="<?php _e( '豆瓣', 'mdx' ); ?>">
+                    </td>
+                </tr>
+                <tr>
+                    <th scope="row"><label for="mdx_sn_github"><?php _e( 'GitHub', 'mdx' ); ?></label></th>
+                    <td>
+                        <input class="regular-text" name="mdx_sn_github" type="text" id="mdx_sn_github" value="" placeholder="<?php _e( 'GitHub 用户名', 'mdx' ); ?>" oninput="input_onchange()" data-alt="<?php _e( 'GitHub', 'mdx' ); ?>">
+                    </td>
+                </tr>
+                <tr>
+                    <th scope="row"><label for="mdx_sn_facebook"><?php _e( 'Facebook', 'mdx' ); ?></label></th>
+                    <td>
+                        <input class="regular-text" name="mdx_sn_facebook" type="text" id="mdx_sn_facebook" value="" placeholder="<?php _e( 'Fackbook 链接', 'mdx' ); ?>" oninput="input_onchange()" data-alt="<?php _e( 'Facebook', 'mdx' ); ?>">
+                    </td>
+                </tr>
+                <tr>
+                    <th scope="row"><label for="mdx_sn_twitter"><?php _e( 'Twitter', 'mdx' ); ?></label></th>
+                    <td>
+                        <input class="regular-text" name="mdx_sn_twitter" type="text" id="mdx_sn_twitter" value="" placeholder="<?php _e( 'Twitter 用户名', 'mdx' ); ?>" oninput="input_onchange()" data-alt="<?php _e( 'Twitter', 'mdx' ); ?>">
+                    </td>
+                </tr>
+                <tr>
+                    <th scope="row"><label for="mdx_sn_telegram"><?php _e( 'Telegram', 'mdx' ); ?></label></th>
+                    <td>
+                        <input class="regular-text" name="mdx_sn_telegram" type="text" id="mdx_sn_telegram" value="" placeholder="<?php _e( 'Telegram 用户名', 'mdx' ); ?>" oninput="input_onchange()" data-alt="<?php _e( 'Telegram', 'mdx' ); ?>">
+                    </td>
+                </tr>
+                <tr>
+                    <th scope="row"><label for="mdx_sn_steam"><?php _e( 'Steam', 'mdx' ); ?></label></th>
+                    <td>
+                        <input class="regular-text" name="mdx_sn_steam" type="text" id="mdx_sn_steam" value="" placeholder="<?php _e( 'Steam 用户名', 'mdx' ); ?>" oninput="input_onchange()" data-alt="<?php _e( 'Steam', 'mdx' ); ?>">
+                    </td>
+                </tr>
+                <tr>
+                    <th scope="row"><label for="mdx_sn_whatsapp"><?php _e( 'WhatsApp', 'mdx' ); ?></label></th>
+                    <td>
+                        <input class="regular-text" name="mdx_sn_whatsapp" type="text" id="mdx_sn_whatsapp" value="" placeholder="<?php _e( 'WhatsApp 链接', 'mdx' ); ?>" oninput="input_onchange()" data-alt="<?php _e( 'WhatsApp', 'mdx' ); ?>">
+                    </td>
+                </tr>
+                <tr>
+                    <th scope="row"><label for="mdx_sn_instagram"><?php _e( 'Instagram', 'mdx' ); ?></label></th>
+                    <td>
+                        <input class="regular-text" name="mdx_sn_instagram" type="text" id="mdx_sn_instagram" value="" placeholder="<?php _e( 'Instagram 链接', 'mdx' ); ?>" oninput="input_onchange()" data-alt="<?php _e( 'Instagram', 'mdx' ); ?>">
+                    </td>
+                </tr>
+                <tr>
+                    <th scope="row"><label for="mdx_sn_dribbble"><?php _e( 'Dribbble', 'mdx' ); ?></label></th>
+                    <td>
+                        <input class="regular-text" name="mdx_sn_dribbble" type="text" id="mdx_sn_dribbble" value="" placeholder="<?php _e( 'Dribbble 链接', 'mdx' ); ?>" oninput="input_onchange()" data-alt="<?php _e( 'Dribbble', 'mdx' ); ?>">
+                    </td>
+                </tr>
+                <tr>
+                    <th scope="row"><label for="mdx_sn_behance"><?php _e( 'Behance', 'mdx' ); ?></label></th>
+                    <td>
+                        <input class="regular-text" name="mdx_sn_behance" type="text" id="mdx_sn_behance" value="" placeholder="<?php _e( 'Behance 链接', 'mdx' ); ?>" oninput="input_onchange()" data-alt="<?php _e( 'Behance', 'mdx' ); ?>">
+                    </td>
+                </tr>
+                <tr>
+                    <th scope="row"><label for="mdx_sn_tel"><?php _e( '电话', 'mdx' ); ?></label></th>
+                    <td>
+                        <input class="regular-text" name="mdx_sn_tel" type="text" id="mdx_sn_tel" value="" placeholder="<?php _e( '电话号码', 'mdx' ); ?>" oninput="input_onchange()" data-alt="<?php _e( '电话', 'mdx' ); ?>">
+                    </td>
+                </tr>
+                <tr>
+                    <th scope="row"><label for="mdx_sn_email"><?php _e( '邮箱', 'mdx' ); ?></label></th>
+                    <td>
+                        <input class="regular-text" name="mdx_sn_email" type="text" id="mdx_sn_email" value="" placeholder="<?php _e( '邮箱地址', 'mdx' ); ?>" oninput="input_onchange()" data-alt="<?php _e( '邮箱', 'mdx' ); ?>">
+                    </td>
+                </tr>
+                <tr>
+                    <th scope="row"><label for="mdx_sn_personalpage"><?php _e( '个人主页', 'mdx' ); ?></label></th>
+                    <td>
+                        <input class="regular-text" name="mdx_sn_personalpage" type="text" id="mdx_sn_personalpage" value="" placeholder="<?php _e( '个人主页地址', 'mdx' ); ?>" oninput="input_onchange()" data-alt="<?php _e( '个人主页', 'mdx' ); ?>">
+                    </td>
+                </tr>
+                <tr>
+                    <th scope="row"><label for="mdx_sn_rss"><?php _e( 'RSS', 'mdx' ); ?></label></th>
+                    <td>
+                        <input class="regular-text" name="mdx_sn_rss" type="text" id="mdx_sn_rss" value="" placeholder="<?php _e( 'RSS 地址', 'mdx' ); ?>" oninput="input_onchange()" data-alt="<?php _e( 'RSS', 'mdx' ); ?>">
+                    </td>
+                </tr>
+                <tr>
+                    <th scope="row"><label for="mdx_sn_result"><?php _e( '生成结果', 'mdx' ); ?></label></th>
+                    <td><textarea name="mdx_sn_result" id="mdx_sn_result" rows="10" cols="53" readonly></textarea></td>
+                </tr>
+            </table>
+            <script>
+                function input_onchange(ele) {
+                    var html_str = "";
+                    for (ele of jQuery("#TB_ajaxContent .regular-text")) {
+                        if (jQuery(ele).val() !== "") {
+                            if (jQuery(ele).attr("id") === "mdx_sn_qq") {
+                                html_str += '<!-- qq -->\n<span class="mdx-footer-icon-link"><i class="mdx-sn-icon mdx_sn_qq" mdui-tooltip="{content: \'' + jQuery(ele).val() + '\', position: \'top\'}" title="' + jQuery(ele)[0].dataset.alt + '"> </i></span>\n';
+                            } else if (jQuery(ele).attr("id") === "mdx_sn_wechat") {
+                                html_str += '<!-- wechat -->\n<span style="--background:url(' + jQuery(ele).val() + ')" class="mdx-sn-wechat-qr mdx-footer-icon-link"><i class="mdx-sn-icon mdx_sn_wechat" title="' + jQuery(ele)[0].dataset.alt + '"> </i></span>\n';
+                            } else if (jQuery(ele).attr("id") === "mdx_sn_tel") {
+                                html_str += '<!-- tel -->\n<a class="mdx-footer-icon-link" href="tel:' + jQuery(ele).val() + '"><i class="mdx-sn-icon mdx_sn_tel" mdui-tooltip="{content: \'' + jQuery(ele).val() + '\', position: \'top\'}" title="' + jQuery(ele)[0].dataset.alt + '"> </i></a>\n';
+                            } else if (jQuery(ele).attr("id") === "mdx_sn_github") {
+                                html_str += '<!-- github -->\n<a class="mdx-footer-icon-link" href="https://github.com/' + jQuery(ele).val() + '"><i class="mdx-sn-icon mdx_sn_github" mdui-tooltip="{content: \'@' + jQuery(ele).val() + '\', position: \'top\'}" title="' + jQuery(ele)[0].dataset.alt + '"> </i></a>\n';
+                            } else if (jQuery(ele).attr("id") === "mdx_sn_twitter") {
+                                html_str += '<!-- twitter -->\n<a class="mdx-footer-icon-link" href="https://twitter.com/' + jQuery(ele).val() + '"><i class="mdx-sn-icon mdx_sn_twitter" mdui-tooltip="{content: \'@' + jQuery(ele).val() + '\', position: \'top\'}" title="' + jQuery(ele)[0].dataset.alt + '"> </i></a>\n';
+                            } else if (jQuery(ele).attr("id") === "mdx_sn_telegram") {
+                                html_str += '<!-- telegram -->\n<a class="mdx-footer-icon-link" href="https://t.me/' + jQuery(ele).val() + '"><i class="mdx-sn-icon mdx_sn_telegram" mdui-tooltip="{content: \'@' + jQuery(ele).val() + '\', position: \'top\'}" title="' + jQuery(ele)[0].dataset.alt + '"> </i></a>\n';
+                            } else if (jQuery(ele).attr("id") === "mdx_sn_steam") {
+                                html_str += '<!-- steam -->\n<a class="mdx-footer-icon-link" href="https://steamcommunity.com/id/' + jQuery(ele).val() + '"><i class="mdx-sn-icon mdx_sn_steam" mdui-tooltip="{content: \'' + jQuery(ele).val() + '\', position: \'top\'}" title="' + jQuery(ele)[0].dataset.alt + '"> </i></a>\n';
+                            } else if (jQuery(ele).attr("id") === "mdx_sn_email") {
+                                html_str += '<!-- email -->\n<a class="mdx-footer-icon-link" href="mailto:' + jQuery(ele).val() + '"><i class="mdx-sn-icon mdx_sn_email" mdui-tooltip="{content: \'' + jQuery(ele).val() + '\', position: \'top\'}" title="' + jQuery(ele)[0].dataset.alt + '"> </i></a>\n';
+                            } else {
+                                html_str += '<!-- ' + jQuery(ele).attr("id").split("_").pop() + ' -->\n<a class="mdx-footer-icon-link" href="' + jQuery(ele).val() + '"><i class="mdx-sn-icon ' + jQuery(ele).attr("id") + '" title="' + jQuery(ele)[0].dataset.alt + '"> </i></a>\n';
+                            }
+                        }
+                    }
+                    jQuery("#mdx_sn_result").text(html_str);
+                }
+            </script>
+        </div><?php submit_button(); ?></form>
 </div>
-<?php
-}elseif((isset($_POST['mdx_ref']) && $_POST['mdx_ref'] == 'true') && !(check_admin_referer('mdx_options_update'))){
-?>
-<div class="notice notice-error is-dismissible">
-<p><?php _e('更改未能保存。', 'mdx'); ?></p>
-</div>
-<?php
-}?>
-<?php if(get_option('mdx_new_ver') != get_option('mdx_version')){?>
-<div class="notice notice-info is-dismissible">
-<p><?php _e('MDx 已发布新版本 ', 'mdx');echo get_option('mdx_new_ver');_e('。<a href="./admin.php?page=mdx_about">重新检查</a>', 'mdx');?></p>
-</div>
-<?php }
-if(!defined('ALU_VERSION')){
-    define('ALU_VERSION', '1.0.6');
-}
-if(ALU_VERSION !== '1.0.6'){?>
-<div class="notice notice-warning is-dismissible">
-<p><?php _e('你似乎正在使用旧版本的 Alu 表情插件。这与 MDx 2.x 不兼容，你需要前往 <a href="https://doc.flyhigher.top/mdx/zh-CN/config/emoji-in-comment/" target="_blank">MDx 文档</a> 下载安装新版插件。', 'mdx');?></p>
-</div>
-<?php }?>
-<nav class="nav-tab-wrapper wp-clearfix" aria-label="Secondary menu"> 
-    <a href="#" class="nav-tab nav-tab-active mdx-admin-nav" id="mdx-admin-nav-global"><?php _e('全局', 'mdx');?></a>
-    <a href="#" class="nav-tab mdx-admin-nav" id="mdx-admin-nav-index"><?php _e('首页', 'mdx');?></a>
-    <a href="#" class="nav-tab mdx-admin-nav" id="mdx-admin-nav-post"><?php _e('文章页', 'mdx');?></a>
-    <a href="#" class="nav-tab mdx-admin-nav" id="mdx-admin-nav-post-list"><?php _e('文章列表', 'mdx');?></a>
-    <a href="#" class="nav-tab mdx-admin-nav" id="mdx-admin-nav-title-bar"><?php _e('标题栏', 'mdx');?></a>
-    <a href="#" class="nav-tab mdx-admin-nav" id="mdx-admin-nav-drawer"><?php _e('抽屉菜单', 'mdx');?></a>
-    <a href="#" class="nav-tab mdx-admin-nav" id="mdx-admin-nav-footer"><?php _e('页脚', 'mdx');?></a>
-    <a href="#" class="nav-tab mdx-admin-nav" id="mdx-admin-nav-touch-bar-icon"><?php _e('Touch Bar 图标', 'mdx');?></a>
-    <a href="#" class="nav-tab mdx-admin-nav" id="mdx-admin-nav-others"><?php _e('杂项', 'mdx');?></a>
-</nav>
-<form method="post" action="">
-<?php
-wp_nonce_field('mdx_options_update');
-?>
-<input type='hidden' name='mdx_ref' value='true'>
-<table class="form-table">
-<tbody class="mdx-admin-section mdx-admin-section-active" id="mdx-admin-nav-global-section">
-    <tr>
-    <th scope="row"><label for="mdx_styles"><?php _e('主题颜色', 'mdx');?></label></th>
-    <td>
-    <?php $mdx_v_styles=mdx_get_option('mdx_styles');?>
-    <select name="mdx_styles" id="mdx_styles">
-        <option value="red" <?php if($mdx_v_styles=='red'){?>selected="selected"<?php }?>>Red</option>
-        <option value="pink" <?php if($mdx_v_styles=='pink'){?>selected="selected"<?php }?>>Pink</option>
-        <option value="purple" <?php if($mdx_v_styles=='purple'){?>selected="selected"<?php }?>>Purple</option>
-        <option value="deep-purple" <?php if($mdx_v_styles=='deep-purple'){?>selected="selected"<?php }?>>Deep Purple</option>
-        <option value="indigo" <?php if($mdx_v_styles=='indigo'){?>selected="selected"<?php }?>>Indigo</option>
-        <option value="blue" <?php if($mdx_v_styles=='blue'){?>selected="selected"<?php }?>>Blue</option>
-        <option value="light-blue" <?php if($mdx_v_styles=='light-blue'){?>selected="selected"<?php }?>>Light Blue</option>
-        <option value="cyan" <?php if($mdx_v_styles=='cyan'){?>selected="selected"<?php }?>>Cyan</option>
-        <option value="teal" <?php if($mdx_v_styles=='teal'){?>selected="selected"<?php }?>>Teal</option>
-        <option value="green" <?php if($mdx_v_styles=='green'){?>selected="selected"<?php }?>>Green</option>
-        <option value="light-green" <?php if($mdx_v_styles=='light-green'){?>selected="selected"<?php }?>>Light Green</option>
-        <option value="lime" <?php if($mdx_v_styles=='lime'){?>selected="selected"<?php }?>>Lime</option>
-        <option value="yellow" <?php if($mdx_v_styles=='yellow'){?>selected="selected"<?php }?>>Yellow</option>
-        <option value="amber" <?php if($mdx_v_styles=='amber'){?>selected="selected"<?php }?>>Amber</option>
-        <option value="orange" <?php if($mdx_v_styles=='orange'){?>selected="selected"<?php }?>>Orange</option>
-        <option value="deep-orange" <?php if($mdx_v_styles=='deep-orange'){?>selected="selected"<?php }?>>Deep Orange</option>
-        <option value="brown" <?php if($mdx_v_styles=='brown'){?>selected="selected"<?php }?>>Brown</option>
-        <option value="grey" <?php if($mdx_v_styles=='grey'){?>selected="selected"<?php }?>>Grey</option>
-        <option value="blue-grey" <?php if($mdx_v_styles=='blue-grey'){?>selected="selected"<?php }?>>Blue Grey</option>
-        <option value="white" <?php if($mdx_v_styles=='white'){?>selected="selected"<?php }?>>White</option>
-    </select>
-    <p class="description"><span class="mdx-color-preview mdx-theme-color-preview"></span> <?php _e('主题颜色会影响所有页面的主色。', 'mdx');?></p>
-    </td>
-    </tr>
-    <tr>
-    <th scope="row"><label for="mdx_styles_act"><?php _e('强调颜色', 'mdx');?></label></th>
-    <td>
-    <?php $mdx_v_styles_act=mdx_get_option('mdx_styles_act');?>
-    <select name="mdx_styles_act" id="mdx_styles_act">
-        <option value="red" <?php if($mdx_v_styles_act=='red'){?>selected="selected"<?php }?>>Red</option>
-        <option value="pink" <?php if($mdx_v_styles_act=='pink'){?>selected="selected"<?php }?>>Pink</option>
-        <option value="purple" <?php if($mdx_v_styles_act=='purple'){?>selected="selected"<?php }?>>Purple</option>
-        <option value="deep-purple" <?php if($mdx_v_styles_act=='deep-purple'){?>selected="selected"<?php }?>>Deep Purple</option>
-        <option value="indigo" <?php if($mdx_v_styles_act=='indigo'){?>selected="selected"<?php }?>>Indigo</option>
-        <option value="blue" <?php if($mdx_v_styles_act=='blue'){?>selected="selected"<?php }?>>Blue</option>
-        <option value="light-blue" <?php if($mdx_v_styles_act=='light-blue'){?>selected="selected"<?php }?>>Light Blue</option>
-        <option value="cyan" <?php if($mdx_v_styles_act=='cyan'){?>selected="selected"<?php }?>>Cyan</option>
-        <option value="teal" <?php if($mdx_v_styles_act=='teal'){?>selected="selected"<?php }?>>Teal</option>
-        <option value="green" <?php if($mdx_v_styles_act=='green'){?>selected="selected"<?php }?>>Green</option>
-        <option value="light-green" <?php if($mdx_v_styles_act=='light-green'){?>selected="selected"<?php }?>>Light Green</option>
-        <option value="lime" <?php if($mdx_v_styles_act=='lime'){?>selected="selected"<?php }?>>Lime</option>
-        <option value="yellow" <?php if($mdx_v_styles_act=='yellow'){?>selected="selected"<?php }?>>Yellow</option>
-        <option value="amber" <?php if($mdx_v_styles_act=='amber'){?>selected="selected"<?php }?>>Amber</option>
-        <option value="orange" <?php if($mdx_v_styles_act=='orange'){?>selected="selected"<?php }?>>Orange</option>
-        <option value="deep-orange" <?php if($mdx_v_styles_act=='deep-orange'){?>selected="selected"<?php }?>>Deep Orange</option>
-    </select>
-    <p class="description"><span class="mdx-color-preview mdx-accent-color-preview"></span> <?php _e('强调颜色会影响所有页面的强调色。', 'mdx');?></p>
-    </td>
-    </tr>
-    <tr>
-    <th scope="row"><label for="mdx_styles_dark"><?php _e('黑暗主题', 'mdx');?></label></th>
-    <td>
-    <?php $mdx_v_styles_dark=mdx_get_option('mdx_styles_dark');?>
-    <select name="mdx_styles_dark" id="mdx_styles_dark">
-        <option value="disable" <?php if($mdx_v_styles_dark=='disable'){?>selected="selected"<?php }?>><?php _e('禁用', 'mdx');?></option>
-        <option value="dark" <?php if($mdx_v_styles_dark=='dark'){?>selected="selected"<?php }?>><?php _e('启用', 'mdx');?></option>
-        <option value="oled" <?php if($mdx_v_styles_dark=='oled'){?>selected="selected"<?php }?>><?php _e('启用 (OLED)', 'mdx');?></option>
-    </select>
-    <p class="description"><?php _e('如果启用，页面将忽略夜间模式相关设置并强制始终以黑暗主题显示。', 'mdx');?></p>
-    </td>
-    </tr>
-    <tr>
-    <th scope="row"><?php _e('Material Design 2', 'mdx');?></th>
-    <td>
-    <?php $mdx_v_md2=mdx_get_option('mdx_md2');?>
-        <fieldset>
-        <label><input type="radio" class="md2" name="mdx_md2" value="true" <?php if($mdx_v_md2=='true'){?>checked="checked"<?php }?>> <?php echo $trueon;?></label><br>
-        <label><input type="radio" class="md2" name="mdx_md2" value="false" <?php if($mdx_v_md2=='false'){?>checked="checked"<?php }?>> <?php echo $falseoff;?></label><br>
-        <p class="description"><?php _e('开启后，主题将会使用 Material Design 2 风格。', 'mdx');?></p>
-        </fieldset>
-    </td>
-    </tr>
-    <tr class="md2_font">
-    <th scope="row"><?php _e('Material Design 2 字体', 'mdx');?></th>
-    <td>
-    <?php $mdx_v_md2_font=mdx_get_option('mdx_md2_font');?>
-        <fieldset>
-        <label><input type="radio" name="mdx_md2_font" value="true" <?php if($mdx_v_md2_font=='true'){?>checked="checked"<?php }?>> <?php echo $trueon;?></label><br>
-        <label><input type="radio" name="mdx_md2_font" value="false" <?php if($mdx_v_md2_font=='false'){?>checked="checked"<?php }?>> <?php echo $falseoff;?></label><br>
-        <p class="description"><?php _e('开启后，部分标题文字将会使用 Material Design 2 风格字体显示。<strong>请注意该字体仅包含拉丁字符。</strong>', 'mdx');?></p>
-        </fieldset>
-    </td>
-    </tr>
-    <tr>
-    <th scope="row"><?php _e('移动 Chrome 标题栏颜色', 'mdx');?></th>
-    <td>
-    <?php $mdx_v_chrome_color=mdx_get_option('mdx_chrome_color');?>
-        <fieldset>
-        <label><input type="radio" name="mdx_chrome_color" value="true" <?php if($mdx_v_chrome_color=='true'){?>checked="checked"<?php }?>> <?php echo $trueon;?></label><br>
-        <label><input type="radio" name="mdx_chrome_color" value="false" <?php if($mdx_v_chrome_color=='false'){?>checked="checked"<?php }?>> <?php echo $falseoff;?></label><br>
-        <p class="description"><?php _e('开启后，移动 Chrome 访问时，其标题栏的背景颜色会随主题颜色变化。', 'mdx');?></p>
-        </fieldset>
-    </td>
-    </tr>
-    <tr>
-    <th scope="row"><?php _e('文章无特色图像时显示默认图像', 'mdx');?></th>
-    <td>
-    <?php $mdx_v_post_def_img=mdx_get_option('mdx_post_def_img');?>
-        <fieldset>
-        <label><input type="radio" name="mdx_post_def_img" value="true" <?php if($mdx_v_post_def_img=='true'){?>checked="checked"<?php }?>> <?php echo $trueon;?></label><br>
-        <label><input type="radio" name="mdx_post_def_img" value="false" <?php if($mdx_v_post_def_img=='false'){?>checked="checked"<?php }?>> <?php echo $falseoff;?></label><br>
-        <p class="description"><?php _e('开启后，文章无特色图像时将显示默认图像，影响文章列表和文章页。若关闭则不显示。', 'mdx');?></p>
-        </fieldset>
-    </td>
-    </tr>
-    <tr>
-    <th scope="row"><?php _e('文章默认特色图像', 'mdx');?></th>
-    <td>
-    <input name="mdx_post_def_img_url" type="text" id="mdx_post_def_img_url" value="<?php echo esc_attr(mdx_get_option('mdx_post_def_img_url'))?>" class="regular-text">
-    <button type="button" id="insert-media-button-5" class="button" style="margin-top:5px;display:block"><?php _e('选择图片', 'mdx');?></button>
-    <p class="description"><?php _e('指定文章默认特色图像，留空则使用主题内置默认特色图像。', 'mdx');?></p>
-    <img id="img5" style="width:100%;max-width:300px;height:auto;margin-top:5px;"></img>
-    </td>
-    </tr>
-</tbody>
-
-<tbody class="mdx-admin-section" id="mdx-admin-nav-index-section">
-    <tr>
-    <th scope="row"><label for="mdx_index_show"><?php _e('首页样式', 'mdx');?></label></th>
-    <td>
-    <?php $mdx_v_index_show=mdx_get_option('mdx_index_show');?>
-    <select name="mdx_index_show" id="mdx_index_show">
-        <option value="0" <?php if($mdx_v_index_show=='0'){?>selected="selected"<?php }?>><?php _e('默认', 'mdx');?></option>
-        <option value="1" <?php if($mdx_v_index_show=='1'){?>selected="selected"<?php }?>><?php _e('简单', 'mdx');?></option>
-        <option value="2" <?php if($mdx_v_index_show=='2'){?>selected="selected"<?php }?>><?php _e('两栏', 'mdx');?></option>
-        <!-- <option value="3" <?php if($mdx_v_index_show=='3'){?>selected="selected"<?php }?>><?php _e('现代', 'mdx');?></option> -->
-        <option value="4" <?php if($mdx_v_index_show=='4'){?>selected="selected"<?php }?>><?php _e('朴素', 'mdx');?></option>
-    </select>
-    <div class="mdx-svg-preview" id="mdx-index-preview"></div>
-    </td>
-    </tr>
-    <tr>
-    <th scope="row"><?php _e('首页图片', 'mdx');?></th>
-    <td>
-    <input name="mdx_index_img" type="text" id="mdx_index_img" value="<?php echo esc_attr(mdx_get_option('mdx_index_img'))?>" class="regular-text" required="required">
-    <button type="button" id="insert-media-button" class="button"><?php _e('选择图片', 'mdx');?></button> <button type="button" id="use-bing-api" class="button mdx_stbsip8"><?php _e('使用必应美图', 'mdx');?></button>
-    <p class="description"><?php _e('你可以上传或指定你的媒体库中的图片作为首页上方显示的图片。<strong>注意，“简单”和“朴素”首页样式不会显示首页图片。</strong><br>无论你是否使用首页幻灯片，你都需要设定一张首页图片。<br>如使用必应美图，可在括号内指定图片的日期。0为今日图片，-1为明日准备使用的图片，1为昨日的图片，以此类推，最多到前16日。', 'mdx');?></p>
-    <img id="img1" style="width:100%;max-width:300px;height:auto;margin-top:5px;"></img>
-    </td>
-    </tr>
-    <tr>
-    <th scope="row"><?php _e('增加首页图片文字对比度', 'mdx');?></th>
-    <td>
-    <?php $mdx_v_index_img_bg=mdx_get_option('mdx_index_img_bg');?>
-    <fieldset>
-        <label><input type="radio" name="mdx_index_img_bg" value="true" <?php if($mdx_v_index_img_bg=='true'){?>checked="checked"<?php }?>> <?php echo $trueon;?></label><br>
-        <label><input type="radio" name="mdx_index_img_bg" value="false" <?php if($mdx_v_index_img_bg=='false'){?>checked="checked"<?php }?>> <?php echo $falseoff;?></label><br>
-        <p class="description"><?php _e('在首页图片中含大面积白色导致首页格言无法看清时启用此选项。在部分首页样式下不生效。', 'mdx');?></p>
-    </fieldset>
-    </td>
-    </tr>
-    <tr>
-    <th scope="row"><?php _e('首页头部展示内容', 'mdx');?></th>
-    <td>
-    <?php $mdx_v_index_head_style=mdx_get_option('mdx_index_head_style');?>
-    <fieldset>
-        <label><input class="mdx-index-head-style-input" type="radio" name="mdx_index_head_style" value="saying" <?php if($mdx_v_index_head_style=='saying'){?>checked="checked"<?php }?>> <?php _e('格言', 'mdx');?></label><br>
-        <label><input class="mdx-index-head-style-input" type="radio" name="mdx_index_head_style" value="slide" <?php if($mdx_v_index_head_style=='slide'){?>checked="checked"<?php }?>> <?php _e('幻灯片', 'mdx');?></label><br>
-        <p class="description"><?php _e('指定首页头部展示的内容。在下方进行详细设置。', 'mdx');?></p>
-    </fieldset>
-    </td>
-    </tr>
-    <tr class="mdx_index_head_style_saying">
-    <th scope="row"><?php _e('首页格言', 'mdx');?></th>
-    <td>
-    <input name="mdx_index_say" type="text" id="mdx_index_say" value="<?php echo esc_attr(mdx_get_option('mdx_index_say'))?>" class="regular-text mdx_index_head_style">
-    <p class="description"><?php _e('这句话会展示在首页。', 'mdx');?></p>
-    </td>
-    </tr>
-    <tr class="mdx_index_head_style_saying">
-    <th scope="row"><label for="mdx_index_say_size"><?php _e('首页格言字体大小', 'mdx');?></label></th>
-    <td>
-    <?php $mdx_v_index_say_size=mdx_get_option('mdx_index_say_size');?>
-    <select name="mdx_index_say_size" id="mdx_index_say_size">
-        <option value="1" <?php if($mdx_v_index_say_size=='1'){?>selected="selected"<?php }?>>H1</option>
-        <option value="2" <?php if($mdx_v_index_say_size=='2'){?>selected="selected"<?php }?>>H2</option>
-        <option value="3" <?php if($mdx_v_index_say_size=='3'){?>selected="selected"<?php }?>>H3</option>
-        <option value="4" <?php if($mdx_v_index_say_size=='4'){?>selected="selected"<?php }?>>H4</option>
-        <option value="5" <?php if($mdx_v_index_say_size=='5'){?>selected="selected"<?php }?>>H5</option>
-        <option value="6" <?php if($mdx_v_index_say_size=='6'){?>selected="selected"<?php }?>>H6</option>
-    </select>
-    <p class="description"><?php _e('字体大小由 H1 至 H6 依次变小。在部分首页样式中无效。', 'mdx');?></p>
-    </td>
-    </tr>
-    <tr class="mdx_index_head_style_slide">
-    <th scope="row"><label for="mdx_index_slide_posts_style"><?php _e('首页幻灯片样式', 'mdx');?></label></th>
-    <td>
-    <?php $mdx_v_index_slide_posts_style=mdx_get_option('mdx_index_slide_posts_style');?>
-    <select name="mdx_index_slide_posts_style" id="mdx_index_slide_posts_style">
-        <option value="1" <?php if($mdx_v_index_slide_posts_style=='1'){?>selected="selected"<?php }?>><?php _e('居中', 'mdx');?></option>
-        <option value="2" <?php if($mdx_v_index_slide_posts_style=='2'){?>selected="selected"<?php }?>><?php _e('现代', 'mdx');?></option>
-        <option value="3" <?php if($mdx_v_index_slide_posts_style=='3'){?>selected="selected"<?php }?>><?php _e('朴素', 'mdx');?></option>
-        <option value="4" <?php if($mdx_v_index_slide_posts_style=='4'){?>selected="selected"<?php }?>><?php _e('纯色', 'mdx');?></option>
-    </select>
-    </td>
-    </tr>
-    <tr class="mdx_index_head_style_slide">
-        <th scope="row"><label for="mdx_index_slide_posts_num"><?php _e('首页幻灯片文章数量', 'mdx');?></label></th>
-        <td><input name="mdx_index_slide_posts_num" type="number" min="1" id="mdx_index_slide_posts_num" value="<?php echo esc_attr(mdx_get_option('mdx_index_slide_posts_num'))?>" class="regular-text">
-        <p class="description"><?php _e('在此设定首页幻灯片文章篇数。请输入整数。', 'mdx');?></p></td>
-    </tr>
-    <tr class="mdx_index_head_style_slide">
-        <th scope="row"><label for="mdx_index_slide_interval"><?php _e('首页幻灯片自动切换时间', 'mdx');?></label></th>
-        <td><input name="mdx_index_slide_interval" type="number" min="1" id="mdx_index_slide_interval" value="<?php echo esc_attr(mdx_get_option('mdx_index_slide_interval'))?>" class="regular-text">
-        <p class="description"><?php _e('单位为秒。请输入整数。', 'mdx');?></p></td>
-    </tr>
-    <tr class="mdx_index_head_style_slide">
-    <th scope="row"><?php _e('首页幻灯片文章获取方式', 'mdx');?></th>
-    <td>
-    <?php $mdx_v_index_slide_posts_get=mdx_get_option('mdx_index_slide_posts_get');?>
-        <fieldset>
-        <label><input type="radio" class="mdx_index_get" name="mdx_index_slide_posts_get" value="cat" <?php if($mdx_v_index_slide_posts_get=='cat'){?>checked="checked"<?php }?>> <?php _e('某一分类', 'mdx');?></label><br>
-        <label><input type="radio" class="mdx_index_get" name="mdx_index_slide_posts_get" value="sticky" <?php if($mdx_v_index_slide_posts_get=='sticky'){?>checked="checked"<?php }?>> <?php _e('置顶文章', 'mdx');?></label><br>
-        <p class="description"><?php _e('在此设定首页幻灯片文章的获取方式。<br>若选择置顶文章，当没有置顶文章时，将会显示首页图片，同时文章列表将保持原始顺序而不会被置顶文章打乱。', 'mdx');?></p>
-        </fieldset>
-    </td>
-    </tr>
-    <tr class="mdx_index_head_style_slide">
-    <th scope="row"><label for="mdx_index_slide_posts_cat"><?php _e('首页幻灯片文章分类名', 'mdx');?></label></th>
-    <td><input name="mdx_index_slide_posts_cat" type="text" id="mdx_index_slide_posts_cat" value="<?php echo esc_attr(mdx_get_option('mdx_index_slide_posts_cat'))?>" class="regular-text">
-    <p class="description"><?php _e('在此设定首页幻灯片文章的分类名。当分类不存在时，将显示最新文章。', 'mdx');?></p></td>
-    </tr>
-</tbody>
-
-<tbody class="mdx-admin-section" id="mdx-admin-nav-post-section">
-    <tr>
-    <th scope="row"><label for="mdx_post_style"><?php _e('文章页样式', 'mdx');?></label></th>
-    <td>
-    <?php $mdx_v_post_style=mdx_get_option('mdx_post_style');?>
-    <select name="mdx_post_style" id="mdx_post_style">
-        <option value="0" <?php if($mdx_v_post_style=='0'){?>selected="selected"<?php }?>><?php _e('标准', 'mdx');?></option>
-        <option value="1" <?php if($mdx_v_post_style=='1'){?>selected="selected"<?php }?>><?php _e('简洁', 'mdx');?></option>
-        <option value="2" <?php if($mdx_v_post_style=='2'){?>selected="selected"<?php }?>><?php _e('通透', 'mdx');?></option>
-        <option value="3" <?php if($mdx_v_post_style=='3'){?>selected="selected"<?php }?>><?php _e('朴素', 'mdx');?></option>
-    </select>
-    <div class="mdx-svg-preview" id="mdx-post-preview"></div>
-    <p class="description"><?php _e('同时影响文章页、单独页面的样式。', 'mdx');?></p>
-    </td>
-    </tr>
-    <tr>
-    <th scope="row"><label for="mdx_post_time_positon"><?php _e('文章时间显示位置', 'mdx');?></label></th>
-    <td>
-    <?php $mdx_v_post_time_positon=mdx_get_option('mdx_post_time_positon');?>
-    <select name="mdx_post_time_positon" id="mdx_post_time_positon">
-        <option value="title" <?php if($mdx_v_post_time_positon=='title'){?>selected="selected"<?php }?>><?php _e('标题旁', 'mdx');?></option>
-        <option value="foot" <?php if($mdx_v_post_time_positon=='foot'){?>selected="selected"<?php }?>><?php _e('文章末尾', 'mdx');?></option>
-        <option value="none" <?php if($mdx_v_post_time_positon=='none'){?>selected="selected"<?php }?>><?php _e('不显示', 'mdx');?></option>
-    </select>
-    </td>
-    </tr>
-    <tr>
-    <th scope="row"><label for="mdx_post_nav_style"><?php _e('文章导航栏配色方案', 'mdx');?></label></th>
-    <td>
-    <?php $mdx_v_post_nav_style=mdx_get_option('mdx_post_nav_style');?>
-    <select name="mdx_post_nav_style" id="mdx_post_nav_style">
-        <option value="0" <?php if($mdx_v_post_nav_style=='0'){?>selected="selected"<?php }?>><?php _e('主题色', 'mdx');?></option>
-        <option value="1" <?php if($mdx_v_post_nav_style=='1'){?>selected="selected"<?php }?>><?php _e('低饱和度', 'mdx');?></option>
-    </select>
-    <p class="description"><?php _e('影响文章末尾文章导航栏区域的配色。', 'mdx');?></p>
-    </td>
-    </tr>
-    <tr>
-        <th scope="row"><label for="mdx_say_after"><?php _e('文末信息', 'mdx');?></label></th>
-        <td><textarea name="mdx_say_after" id="mdx_say_after" rows="7" cols="50"><?php echo mdx_get_option('mdx_say_after')?></textarea>
-        <p class="description"><?php _e('在这里编辑文末信息。文末信息会显示在每篇文章的底部，留空则不会显示。支持 <code>HTML</code> 格式。<code>--PostLink--</code> 会被替换为链接到当前文章的文章标题，<code>--PostURL--</code> 会被替换为链接到当前文章的当前文章 URL（大小写敏感）。', 'mdx');?></p></td>
-    </tr>
-</tbody>
-
-<tbody class="mdx-admin-section" id="mdx-admin-nav-post-list-section">
-    <tr>
-    <th scope="row"><label for="mdx_default_style"><?php _e('文章列表样式', 'mdx');?></label></th>
-    <td>
-    <?php $mdx_v_default_style=mdx_get_option('mdx_default_style');?>
-    <select name="mdx_default_style" id="mdx_default_style">
-        <option value="1" <?php if($mdx_v_default_style=='1'){?>selected="selected"<?php }?>><?php _e('简洁', 'mdx');?></option>
-        <option value="2" <?php if($mdx_v_default_style=='2'){?>selected="selected"<?php }?>><?php _e('列表', 'mdx');?></option>
-        <option value="3" <?php if($mdx_v_default_style=='3'){?>selected="selected"<?php }?>><?php _e('干净', 'mdx');?></option>
-        <option value="4" <?php if($mdx_v_default_style=='4'){?>selected="selected"<?php }?>><?php _e('网格', 'mdx');?></option>
-        <option value="5" <?php if($mdx_v_default_style=='5'){?>selected="selected"<?php }?>><?php _e('朴素', 'mdx');?></option>
-        <!-- <option value="6" <?php if($mdx_v_default_style=='6'){?>selected="selected"<?php }?>><?php _e('现代', 'mdx');?></option> -->
-    </select>
-    <div class="mdx-svg-preview" id="mdx-list-preview"></div>
-    <p class="description"><?php _e('同时影响首页、搜索结果页、归档页的文章列表样式。', 'mdx');?></p>
-    </td>
-    </tr>
-    <tr>
-    <th scope="row"><?php _e('文章列表宽度', 'mdx');?></th>
-    <td>
-    <?php $mdx_v_post_list_width=mdx_get_option('mdx_post_list_width');?>
-        <fieldset>
-        <label><input type="radio" name="mdx_post_list_width" value="normal" <?php if($mdx_v_post_list_width=='normal'){?>checked="checked"<?php }?>> <?php _e('正常', 'mdx');?></label><br>
-        <label><input type="radio" name="mdx_post_list_width" value="wide" <?php if($mdx_v_post_list_width=='wide'){?>checked="checked"<?php }?>> <?php _e('较宽', 'mdx');?></label><br>
-        </fieldset>
-        <p class="description"><?php _e('使用“较宽”，文章列表将会以多列瀑布流显示。', 'mdx');?></p>
-    </td>
-    </tr>
-    <tr>
-    <th scope="row"><?php _e('文章列表显示文章摘要', 'mdx');?></th>
-    <td>
-    <?php $mdx_v_echo_post_sum=mdx_get_option('mdx_echo_post_sum');?>
-        <fieldset>
-        <label><input type="radio" name="mdx_echo_post_sum" value="true" <?php if($mdx_v_echo_post_sum=='true'){?>checked="checked"<?php }?>> <?php echo $trueon;?></label><br>
-        <label><input type="radio" name="mdx_echo_post_sum" value="false" <?php if($mdx_v_echo_post_sum=='false'){?>checked="checked"<?php }?>> <?php echo $falseoff;?></label><br>
-        <p class="description"><?php _e('开启后，文章列表可显示每篇文章的摘要，影响首页和归档页。若关闭则不显示。', 'mdx');?></p>
-        </fieldset>
-    </td>
-    </tr>
-    <tr>
-    <th scope="row"><label for="mdx_post_list_img_height"><?php _e('文章列表图片高度', 'mdx');?></label></th>
-    <td>
-    <?php $mdx_v_post_list_img_height=mdx_get_option('mdx_post_list_img_height');?>
-    <select name="mdx_post_list_img_height" id="mdx_post_list_img_height">
-        <option value="auto" <?php if($mdx_v_post_list_img_height=='auto'){?>selected="selected"<?php }?>><?php _e('自适应', 'mdx');?></option>
-        <option value="fixed" <?php if($mdx_v_post_list_img_height=='fixed'){?>selected="selected"<?php }?>><?php _e('固定宽高比', 'mdx');?></option>
-    </select>
-    <p class="description"><?php _e('选择 <code>自适应</code>，文章特色图像可以完全展示。<br>选择 <code>固定宽高比</code>，文章特色图像可能会只显示部分以保持宽高比，但图像不会被拉伸，适合于图像过宽/过高的情况。', 'mdx');?></p>
-    </td>
-    </tr>
-</tbody>
-
-<tbody class="mdx-admin-section" id="mdx-admin-nav-title-bar-section">
-    <tr>
-    <th scope="row"><?php _e('自动隐藏标题栏', 'mdx');?></th>
-    <td>
-    <?php $mdx_v_title_bar=mdx_get_option('mdx_title_bar');?>
-        <fieldset>
-        <label><input type="radio" name="mdx_title_bar" value="true" <?php if($mdx_v_title_bar=='true'){?>checked="checked"<?php }?>> <?php echo $trueon;?></label><br>
-        <label><input type="radio" name="mdx_title_bar" value="false" <?php if($mdx_v_title_bar=='false'){?>checked="checked"<?php }?>> <?php echo $falseoff;?></label><br>
-        <p class="description"><?php _e('开启后，页面向下滚动时标题栏会向上隐藏，向上滚动时会出现。', 'mdx');?></p>
-        </fieldset>
-    </td>
-    </tr>
-    <tr>
-    <th scope="row"><label for="mdx_logo_way"><?php _e('标题栏显示内容', 'mdx');?></label></th>
-    <td>
-    <?php $mdx_v_logo_way=mdx_get_option('mdx_logo_way');?>
-    <select name="mdx_logo_way" id="mdx_logo_way" onchange="mdx_logo_sec(this.options[this.options.selectedIndex].value)">
-        <option value="1" <?php if($mdx_v_logo_way=='1'){?>selected="selected"<?php }?>><?php _e('博客名称', 'mdx');?></option>
-        <option value="2" <?php if($mdx_v_logo_way=='2'){?>selected="selected"<?php }?>><?php _e('自定义 Logo', 'mdx');?></option>
-        <option value="3" <?php if($mdx_v_logo_way=='3'){?>selected="selected"<?php }?>><?php _e('自定义名称', 'mdx');?></option>
-    </select>
-    </td>
-    </tr>
-    <tr class="logo_logo">
-    <th scope="row"><?php _e('标题栏 Logo', 'mdx');?></th>
-    <td>
-    <input name="mdx_logo" type="url" id="mdx_logo" value="<?php echo esc_attr(mdx_get_option('mdx_logo'))?>" class="regular-text">
-    <button type="button" id="insert-media-button-2" class="button"><?php _e('选择图片', 'mdx');?></button>
-    <p class="description"><?php _e('选择一张图片作为网站 Logo。', 'mdx');?></p>
-    <img id="img4" style="width:100%;max-width:300px;height:auto;margin-top:5px;"></img>
-    </td>
-    </tr>
-    <tr class="logo_text">
-    <th scope="row"><?php _e('标题栏自定义名称', 'mdx');?></th>
-    <td>
-    <input name="mdx_logo_text" type="text" id="mdx_logo_text" value="<?php echo esc_attr(mdx_get_option('mdx_logo_text'))?>" class="regular-text">
-    </td>
-    </tr>
-    <tr>
-    <th scope="row"><?php _e('点击标题栏返回顶部', 'mdx');?></th>
-    <td>
-    <?php $mdx_v_tap_to_top=mdx_get_option('mdx_tap_to_top');?>
-        <fieldset>
-        <label><input type="radio" name="mdx_tap_to_top" value="true" <?php if($mdx_v_tap_to_top=='true'){?>checked="checked"<?php }?>> <?php echo $trueon;?></label><br>
-        <label><input type="radio" name="mdx_tap_to_top" value="false" <?php if($mdx_v_tap_to_top=='false'){?>checked="checked"<?php }?>> <?php echo $falseoff;?></label><br>
-        <p class="description"><?php _e('开启后，点击标题栏可以返回页面顶部。此设置影响所有页面。', 'mdx');?></p>
-        </fieldset>
-    </td>
-    </tr>
-</tbody>
-
-<tbody class="mdx-admin-section" id="mdx-admin-nav-drawer-section">
-    <tr>
-    <th scope="row"><?php _e('抽屉菜单顶部展示个人信息', 'mdx');?></th>
-    <td>
-    <?php $mdx_v_side_info=mdx_get_option('mdx_side_info');?>
-        <fieldset>
-        <label><input class="mdx_stbs2" type="radio" name="mdx_side_info" value="true" <?php if($mdx_v_side_info=='true'){?>checked="checked"<?php }?>> <?php echo $trueon;?></label><br>
-        <label><input class="mdx_stbs2" type="radio" name="mdx_side_info" value="false" <?php if($mdx_v_side_info=='false'){?>checked="checked"<?php }?>> <?php echo $falseoff;?></label><br>
-        <p class="description"><?php _e('开启后，抽屉顶部会显示头像及名称，请在下方设置。', 'mdx');?></p>
-        </fieldset>
-    </td>
-    </tr>
-    <tr>
-    <th scope="row"><?php _e('抽屉菜单顶部图片', 'mdx');?></th>
-    <td>
-    <input name="mdx_side_img" type="url" id="mdx_side_img" value="<?php echo esc_attr(mdx_get_option('mdx_side_img'))?>" class="regular-text mdx_stbsip2">
-    <button type="button" id="insert-media-button-3" class="button mdx_stbsip22"><?php _e('选择图片', 'mdx');?></button>
-    <img id="img2" style="width:100%;max-width:300px;height:auto;margin-top:5px;"></img>
-    </td>
-    </tr>
-    <tr>
-    <th scope="row"><?php _e('抽屉菜单信息头像', 'mdx');?></th>
-    <td>
-    <input name="mdx_side_head" type="url" id="mdx_side_head" value="<?php echo esc_attr(mdx_get_option('mdx_side_head'))?>" class="regular-text mdx_stbsip22">
-    <button type="button" id="insert-media-button-4" class="button mdx_stbsip1 mdx_stbsip22"><?php _e('选择图片', 'mdx');?></button>
-    <p class="description"><?php _e('选择一张图片作为抽屉顶部显示的头像。留空则不显示。', 'mdx');?></p>
-    <img id="img3" style="width:100%;max-width:300px;height:auto;margin-top:5px;;margin-top:5px;"></img>
-    </td>
-    </tr>
-    <tr>
-    <th scope="row"><?php _e('抽屉菜单信息名称', 'mdx');?></th>
-    <td>
-    <input name="mdx_side_name" type="text" id="mdx_side_name" value="<?php echo esc_attr(mdx_get_option('mdx_side_name'))?>" class="regular-text mdx_stbsip2" required="required">
-    </td>
-    </tr>
-    <tr>
-    <th scope="row"><?php _e('抽屉菜单详细信息', 'mdx');?></th>
-    <td>
-    <input name="mdx_side_more" type="text" id="mdx_side_more" value="<?php echo esc_attr(mdx_get_option('mdx_side_more'))?>" class="regular-text mdx_stbsip2" required="required">
-    <p class="description"><?php _e('这里的内容会显示在抽屉菜单信息名称的下方。', 'mdx');?></p>
-    </td>
-    </tr>
-</tbody>
-
-<tbody class="mdx-admin-section" id="mdx-admin-nav-footer-section">
-    <tr>
-    <th scope="row"><label for="mdx_styles_footer"><?php _e('页脚样式', 'mdx');?></label></th>
-    <td>
-    <?php $mdx_v_styles_footer=mdx_get_option('mdx_styles_footer');?>
-    <select name="mdx_styles_footer" id="mdx_styles_footer">
-        <option value="1" <?php if($mdx_v_styles_footer=='1'){?>selected="selected"<?php }?>><?php _e('传统', 'mdx');?></option>
-        <option value="2" <?php if($mdx_v_styles_footer=='2'){?>selected="selected"<?php }?>><?php _e('简单', 'mdx');?></option>
-        <option value="3" <?php if($mdx_v_styles_footer=='3'){?>selected="selected"<?php }?>><?php _e('现代', 'mdx');?></option>
-    </select>
-    <p class="description"><?php _e('在此设定页脚样式。<strong>如果选择“简单”样式，那么页脚格言将不会显示。</strong>', 'mdx');?></p>
-    </td>
-    </tr>
-    <tr>
-    <th scope="row"><label for="mdx_footer_say"><?php _e('页脚格言', 'mdx');?></label></th>
-    <td><input class="regular-text" name="mdx_footer_say" type="text" id="mdx_footer_say" value="<?php echo esc_attr(mdx_get_option('mdx_footer_say'))?>">
-    <button type="button" id="use-api" class="button mdx_stbsip7"><?php _e('使用一言 API（常规）', 'mdx');?></button>
-    <button type="button" id="use-api2" class="button mdx_stbsip7"><?php _e('使用一言 API（古诗词）', 'mdx');?></button>
-    <button type="button" id="use-api3" class="button mdx_stbsip7"><?php _e('使用一言 API（自定义）', 'mdx');?></button>
-    <p class="description" id="mdx_footer"><?php _e('这句话会显示在每个页面的页脚，如果不希望显示，请留空。若调用一言 API，则每次页面刷新后都会显示不同的格言。此 API 来自第三方，请注意安全风险。', 'mdx');?></p>
-    <p class="description" id="mdx_custom_api"><?php _e('如使用自定义 API，你需要在括号内填写 API URL 并确保 API 返回 <code>{"text":"句子"}</code> 的 JSON 格式。<a href="https://doc.flyhigher.top/mdx/zh-CN/config/custom_api/" target="_blank">详细信息</a></code>', 'mdx');?></p></td>
-    </tr>
-    <tr>
-        <th scope="row"><label for="mdx_footer"><?php _e('页脚内容', 'mdx');?></label></th>
-        <td><textarea name="mdx_footer" id="mdx_footer" rows="7" cols="50"><?php echo mdx_get_option('mdx_footer')?></textarea><br><a class="thickbox button" title="<?php _e('社交网站图标编辑器', 'mdx');?>" href="#TB_inline?height=100%&width=100%&inlineId=social-network-editor" style="margin-top: 5px;"><?php _e('社交网站图标编辑器', 'mdx');?></a>
-        <p class="description"><?php _e('在这里编辑页脚内容。支持 <code>HTML</code> 格式。', 'mdx');?></p></td>
-    </tr>
-</tbody>
-
-<tbody class="mdx-admin-section" id="mdx-admin-nav-touch-bar-icon-section">
-    <tr>
-    <th scope="row"><?php _e('Safari Touch Bar 图标支持', 'mdx');?></th>
-    <td>
-    <?php $mdx_v_safari=mdx_get_option('mdx_safari');?>
-        <fieldset>
-        <label><input class="mdx_stbs" type="radio" name="mdx_safari" value="true" <?php if($mdx_v_safari=='true'){?>checked="checked"<?php }?>> <?php echo $trueon;?></label><br>
-        <label><input class="mdx_stbs" type="radio" name="mdx_safari" value="false" <?php if($mdx_v_safari=='false'){?>checked="checked"<?php }?>> <?php echo $falseoff;?></label><br>
-        </fieldset>
-        <p class="description"><?php _e('开启后会启用对 Safari Touch Bar 图标的支持，请在下方完成相关设置。<a href="https://developer.apple.com/library/content/documentation/AppleApplications/Reference/SafariWebContent/pinnedTabs/pinnedTabs.html" target="_blank">详细了解</a>', 'mdx');?>
-    </td>
-    </tr>
-    <tr>
-    <th scope="row"><label for="mdx_svg"><?php _e('Touch Bar 图标地址', 'mdx');?></label></th>
-    <td><input class="mdx_stbsip regular-text mdx_stbsip3" name="mdx_svg" type="text" id="mdx_svg" value="<?php echo esc_attr(mdx_get_option('mdx_svg'))?>" required="required">
-    <p class="description" id="mdx_footer"><?php _e('请设置 Touch Bar 图标地址。格式为 SVG，必须为单层，viewbox 属性必须为"0 0 16 16"。', 'mdx');?></p></td>
-    </tr>
-    <tr>
-    <th scope="row"><label for="mdx_svg_color"><?php _e('Touch Bar 图标背景颜色', 'mdx');?></label></th>
-    <td><input class="mdx_stbsip regular-text mdx_stbsip3" name="mdx_svg_color" type="text" id="mdx_svg_color" value="<?php echo esc_attr(mdx_get_option('mdx_svg_color'))?>" required="required"><br>
-    <a id="change-color" class="button mdx_stbsip5" href="javascript:jQuery('#mdx_svg_color').val('<?php echo mdx_get_option('mdx_styles_hex');?>');jQuery('#mdx_svg_color').wpColorPicker('color', '<?php echo mdx_get_option('mdx_styles_hex');?>');"><?php _e('使用当前主题颜色', 'mdx');?></a>
-    <p class="description" id="mdx_footer"><?php _e('请设置 Touch Bar 图标背景颜色。16 进制颜色或 RGB 颜色。', 'mdx');?></p></td>
-    </tr>
-</tbody>
-
-<tbody class="mdx-admin-section" id="mdx-admin-nav-others-section">
-    <tr>
-    <th scope="row"><?php _e('登录页 Material Design', 'mdx');?></th>
-    <td>
-    <?php $mdx_v_login_md=mdx_get_option('mdx_login_md');?>
-        <fieldset>
-        <label><input type="radio" name="mdx_login_md" value="true" <?php if($mdx_v_login_md=='true'){?>checked="checked"<?php }?>> <?php echo $trueon;?></label><br>
-        <label><input type="radio" name="mdx_login_md" value="false" <?php if($mdx_v_login_md=='false'){?>checked="checked"<?php }?>> <?php echo $falseoff;?></label><br>
-        <p class="description"><?php _e('将 Material Design 样式应用到登录页。可能与部分插件样式不兼容。', 'mdx');?></p>
-        </fieldset>
-    </td>
-    </tr>
-    <tr>
-    <th scope="row"><?php _e('启用友链 Gravatar 支持', 'mdx');?></th>
-    <td>
-    <?php $mdx_v_gravatar_actived = mdx_get_option('mdx_gravatar_actived'); ?>
-        <fieldset>
-        <label><input type="radio" name="mdx_gravatar_actived" value="true" <?php if($mdx_v_gravatar_actived=='true'){?>checked="checked"<?php }?>> <?php echo $trueon;?></label><br>
-        <label><input type="radio" name="mdx_gravatar_actived" value="false" <?php if($mdx_v_gravatar_actived=='false'){?>checked="checked"<?php }?>> <?php echo $falseoff;?></label><br>
-        <p class="description"><?php _e('开启后，将尝试从备注栏中获取邮箱并将与邮箱对应的 Gravatar 头像作为友情链接图像。关闭则只使用图片链接。', 'mdx');?></p>
-        </fieldset>
-    </td>
-    </tr>
-    <tr>
-    <th scope="row"><?php _e('友情链接随机顺序', 'mdx');?></th>
-    <td>
-    <?php $mdx_v_link_rand_order = mdx_get_option('mdx_link_rand_order'); ?>
-        <fieldset>
-        <label><input type="radio" name="mdx_link_rand_order" value="true" <?php if($mdx_v_link_rand_order=='true'){?>checked="checked"<?php }?>> <?php echo $trueon;?></label><br>
-        <label><input type="radio" name="mdx_link_rand_order" value="false" <?php if($mdx_v_link_rand_order=='false'){?>checked="checked"<?php }?>> <?php echo $falseoff;?></label><br>
-        <p class="description"><?php _e('开启后，友情链接将以随机顺序显示。关闭则使用字典序。', 'mdx');?></p>
-        </fieldset>
-    </td>
-    </tr>
-    <tr>
-    <th scope="row"><label for="mdx_title_med"><?php _e('网页标题计算方式', 'mdx');?></label></th>
-    <td>
-    <?php $mdx_v_title_med=mdx_get_option('mdx_title_med');?>
-    <select name="mdx_title_med" id="mdx_title_med">
-        <option value="wp" <?php if($mdx_v_title_med=='wp'){?>selected="selected"<?php }?>><?php _e('WordPress 默认', 'mdx');?></option>
-        <option value="diy" <?php if($mdx_v_title_med=='diy'){?>selected="selected"<?php }?>><?php _e('MDx 优化', 'mdx');?></option>
-    </select>
-    <p class="description"><?php _e('选择 <code>WordPress 默认</code>，WordPress 会接管网页标题的内容，此方式兼容大部分 SEO 插件。<br>选择 <code>MDx 优化</code>，MDx 会接管网页标题的内容，此方式在部分情况下更合适，但不兼容 SEO 插件。', 'mdx');?></p>
-    </td>
-    </tr>
-    <tr>
-    <th scope="row"><?php _e('多彩标签云', 'mdx');?></th>
-    <td>
-    <?php $mdx_v_tags_color=mdx_get_option('mdx_tags_color');?>
-        <fieldset>
-        <label><input type="radio" name="mdx_tags_color" value="true" <?php if($mdx_v_tags_color=='true'){?>checked="checked"<?php }?>> <?php echo $trueon;?></label><br>
-        <label><input type="radio" name="mdx_tags_color" value="false" <?php if($mdx_v_tags_color=='false'){?>checked="checked"<?php }?>> <?php echo $falseoff;?></label><br>
-        <p class="description"><?php _e('开启后，标签云页面输出的标签会带有随机颜色，反之为同一颜色。', 'mdx');?></p>
-        </fieldset>
-    </td>
-    </tr>
-</tbody>
-</table>
-<div id="social-network-editor" style="display:none;">
-<br>
-<p class="description"><?php _e('在这里获取受 MDx 样式支持的社交网站图标链接。填写完成之后，你可以将获取到的代码粘贴到包括页脚内容在内的任何地方或是自定义代码内容。未填写的项目将被忽略。', 'mdx');?></p>
-<table class="form-table">
-<tr>
-<th scope="row"><label for="mdx_sn_qq"><?php _e('QQ', 'mdx');?></label></th>
-<td><input class="regular-text" name="mdx_sn_qq" type="text" id="mdx_sn_qq" value="" placeholder="<?php _e('QQ 号', 'mdx');?>" oninput="input_onchange()" data-alt="<?php _e('QQ', 'mdx');?>"></td>
-</tr>
-<tr>
-<th scope="row"><label for="mdx_sn_wechat"><?php _e('微信', 'mdx');?></label></th>
-<td><input class="regular-text" name="mdx_sn_wechat" type="text" id="mdx_sn_wechat" value="" placeholder="<?php _e('微信二维码图片链接', 'mdx');?>" oninput="input_onchange()" data-alt="<?php _e('微信', 'mdx');?>"></td>
-</tr>
-<tr>
-<th scope="row"><label for="mdx_sn_weibo"><?php _e('微博', 'mdx');?></label></th>
-<td><input class="regular-text" name="mdx_sn_weibo" type="text" id="mdx_sn_weibo" value="" placeholder="<?php _e('微博链接', 'mdx');?>" oninput="input_onchange()" data-alt="<?php _e('微博', 'mdx');?>"></td>
-</tr>
-<tr>
-<th scope="row"><label for="mdx_sn_zhihu"><?php _e('知乎', 'mdx');?></label></th>
-<td><input class="regular-text" name="mdx_sn_zhihu" type="text" id="mdx_sn_zhihu" value="" placeholder="<?php _e('知乎链接', 'mdx');?>" oninput="input_onchange()" data-alt="<?php _e('知乎', 'mdx');?>"></td>
-</tr>
-<tr>
-<th scope="row"><label for="mdx_sn_bilibili"><?php _e('哔哩哔哩', 'mdx');?></label></th>
-<td><input class="regular-text" name="mdx_sn_bilibili" type="text" id="mdx_sn_bilibili" value="" placeholder="<?php _e('哔哩哔哩链接', 'mdx');?>" oninput="input_onchange()" data-alt="<?php _e('哔哩哔哩', 'mdx');?>"></td>
-</tr>
-<tr>
-<th scope="row"><label for="mdx_sn_neteasemusic"><?php _e('网易云音乐', 'mdx');?></label></th>
-<td><input class="regular-text" name="mdx_sn_neteasemusic" type="text" id="mdx_sn_neteasemusic" value="" placeholder="<?php _e('网易云音乐链接', 'mdx');?>" oninput="input_onchange()" data-alt="<?php _e('网易云音乐', 'mdx');?>"></td>
-</tr>
-<tr>
-<th scope="row"><label for="mdx_sn_coolapk"><?php _e('酷安', 'mdx');?></label></th>
-<td><input class="regular-text" name="mdx_sn_coolapk" type="text" id="mdx_sn_coolapk" value="" placeholder="<?php _e('酷安链接', 'mdx');?>" oninput="input_onchange()" data-alt="<?php _e('酷安', 'mdx');?>"></td>
-</tr>
-<tr>
-<th scope="row"><label for="mdx_sn_douban"><?php _e('豆瓣', 'mdx');?></label></th>
-<td><input class="regular-text" name="mdx_sn_douban" type="text" id="mdx_sn_douban" value="" placeholder="<?php _e('豆瓣链接', 'mdx');?>" oninput="input_onchange()" data-alt="<?php _e('豆瓣', 'mdx');?>"></td>
-</tr>
-<tr>
-<th scope="row"><label for="mdx_sn_github"><?php _e('GitHub', 'mdx');?></label></th>
-<td><input class="regular-text" name="mdx_sn_github" type="text" id="mdx_sn_github" value="" placeholder="<?php _e('GitHub 用户名', 'mdx');?>" oninput="input_onchange()" data-alt="<?php _e('GitHub', 'mdx');?>"></td>
-</tr>
-<tr>
-<th scope="row"><label for="mdx_sn_facebook"><?php _e('Facebook', 'mdx');?></label></th>
-<td><input class="regular-text" name="mdx_sn_facebook" type="text" id="mdx_sn_facebook" value="" placeholder="<?php _e('Fackbook 链接', 'mdx');?>" oninput="input_onchange()" data-alt="<?php _e('Facebook', 'mdx');?>"></td>
-</tr>
-<tr>
-<th scope="row"><label for="mdx_sn_twitter"><?php _e('Twitter', 'mdx');?></label></th>
-<td><input class="regular-text" name="mdx_sn_twitter" type="text" id="mdx_sn_twitter" value="" placeholder="<?php _e('Twitter 用户名', 'mdx');?>" oninput="input_onchange()" data-alt="<?php _e('Twitter', 'mdx');?>"></td>
-</tr>
-<tr>
-<th scope="row"><label for="mdx_sn_telegram"><?php _e('Telegram', 'mdx');?></label></th>
-<td><input class="regular-text" name="mdx_sn_telegram" type="text" id="mdx_sn_telegram" value="" placeholder="<?php _e('Telegram 用户名', 'mdx');?>" oninput="input_onchange()" data-alt="<?php _e('Telegram', 'mdx');?>"></td>
-</tr>
-<tr>
-<th scope="row"><label for="mdx_sn_steam"><?php _e('Steam', 'mdx');?></label></th>
-<td><input class="regular-text" name="mdx_sn_steam" type="text" id="mdx_sn_steam" value="" placeholder="<?php _e('Steam 用户名', 'mdx');?>" oninput="input_onchange()" data-alt="<?php _e('Steam', 'mdx');?>"></td>
-</tr>
-<tr>
-<th scope="row"><label for="mdx_sn_whatsapp"><?php _e('WhatsApp', 'mdx');?></label></th>
-<td><input class="regular-text" name="mdx_sn_whatsapp" type="text" id="mdx_sn_whatsapp" value="" placeholder="<?php _e('WhatsApp 链接', 'mdx');?>" oninput="input_onchange()" data-alt="<?php _e('WhatsApp', 'mdx');?>"></td>
-</tr>
-<tr>
-<th scope="row"><label for="mdx_sn_instagram"><?php _e('Instagram', 'mdx');?></label></th>
-<td><input class="regular-text" name="mdx_sn_instagram" type="text" id="mdx_sn_instagram" value="" placeholder="<?php _e('Instagram 链接', 'mdx');?>" oninput="input_onchange()" data-alt="<?php _e('Instagram', 'mdx');?>"></td>
-</tr>
-<tr>
-<th scope="row"><label for="mdx_sn_dribbble"><?php _e('Dribbble', 'mdx');?></label></th>
-<td><input class="regular-text" name="mdx_sn_dribbble" type="text" id="mdx_sn_dribbble" value="" placeholder="<?php _e('Dribbble 链接', 'mdx');?>" oninput="input_onchange()" data-alt="<?php _e('Dribbble', 'mdx');?>"></td>
-</tr>
-<tr>
-<th scope="row"><label for="mdx_sn_behance"><?php _e('Behance', 'mdx');?></label></th>
-<td><input class="regular-text" name="mdx_sn_behance" type="text" id="mdx_sn_behance" value="" placeholder="<?php _e('Behance 链接', 'mdx');?>" oninput="input_onchange()" data-alt="<?php _e('Behance', 'mdx');?>"></td>
-</tr>
-<tr>
-<th scope="row"><label for="mdx_sn_tel"><?php _e('电话', 'mdx');?></label></th>
-<td><input class="regular-text" name="mdx_sn_tel" type="text" id="mdx_sn_tel" value="" placeholder="<?php _e('电话号码', 'mdx');?>" oninput="input_onchange()" data-alt="<?php _e('电话', 'mdx');?>"></td>
-</tr>
-<tr>
-<th scope="row"><label for="mdx_sn_email"><?php _e('邮箱', 'mdx');?></label></th>
-<td><input class="regular-text" name="mdx_sn_email" type="text" id="mdx_sn_email" value="" placeholder="<?php _e('邮箱地址', 'mdx');?>" oninput="input_onchange()" data-alt="<?php _e('邮箱', 'mdx');?>"></td>
-</tr>
-<tr>
-<th scope="row"><label for="mdx_sn_personalpage"><?php _e('个人主页', 'mdx');?></label></th>
-<td><input class="regular-text" name="mdx_sn_personalpage" type="text" id="mdx_sn_personalpage" value="" placeholder="<?php _e('个人主页地址', 'mdx');?>" oninput="input_onchange()" data-alt="<?php _e('个人主页', 'mdx');?>"></td>
-</tr>
-<tr>
-<th scope="row"><label for="mdx_sn_rss"><?php _e('RSS', 'mdx');?></label></th>
-<td><input class="regular-text" name="mdx_sn_rss" type="text" id="mdx_sn_rss" value="" placeholder="<?php _e('RSS 地址', 'mdx');?>" oninput="input_onchange()" data-alt="<?php _e('RSS', 'mdx');?>"></td>
-</tr>
-<tr>
-    <th scope="row"><label for="mdx_sn_result"><?php _e('生成结果', 'mdx');?></label></th>
-    <td><textarea name="mdx_sn_result" id="mdx_sn_result" rows="10" cols="53" readonly></textarea></td>
-</tr>
-</table>
-<script>
-function input_onchange(ele){
-    var html_str = "";
-    for(ele of jQuery("#TB_ajaxContent .regular-text")){
-        if(jQuery(ele).val() !== ""){
-            if(jQuery(ele).attr("id") === "mdx_sn_qq"){
-                html_str += '<!-- qq -->\n<span class="mdx-footer-icon-link"><i class="mdx-sn-icon mdx_sn_qq" mdui-tooltip="{content: \''+jQuery(ele).val()+'\', position: \'top\'}" title="'+jQuery(ele)[0].dataset.alt+'"> </i></span>\n';
-            }else if(jQuery(ele).attr("id") === "mdx_sn_wechat"){
-                html_str += '<!-- wechat -->\n<span style="--background:url('+jQuery(ele).val()+')" class="mdx-sn-wechat-qr mdx-footer-icon-link"><i class="mdx-sn-icon mdx_sn_wechat" title="'+jQuery(ele)[0].dataset.alt+'"> </i></span>\n';
-            }else if(jQuery(ele).attr("id") === "mdx_sn_tel"){
-                html_str += '<!-- tel -->\n<a class="mdx-footer-icon-link" href="tel:'+jQuery(ele).val()+'"><i class="mdx-sn-icon mdx_sn_tel" mdui-tooltip="{content: \''+jQuery(ele).val()+'\', position: \'top\'}" title="'+jQuery(ele)[0].dataset.alt+'"> </i></a>\n';
-            }else if(jQuery(ele).attr("id") === "mdx_sn_github"){
-                html_str += '<!-- github -->\n<a class="mdx-footer-icon-link" href="https://github.com/'+jQuery(ele).val()+'"><i class="mdx-sn-icon mdx_sn_github" mdui-tooltip="{content: \'@'+jQuery(ele).val()+'\', position: \'top\'}" title="'+jQuery(ele)[0].dataset.alt+'"> </i></a>\n';
-            }else if(jQuery(ele).attr("id") === "mdx_sn_twitter"){
-                html_str += '<!-- twitter -->\n<a class="mdx-footer-icon-link" href="https://twitter.com/'+jQuery(ele).val()+'"><i class="mdx-sn-icon mdx_sn_twitter" mdui-tooltip="{content: \'@'+jQuery(ele).val()+'\', position: \'top\'}" title="'+jQuery(ele)[0].dataset.alt+'"> </i></a>\n';
-            }else if(jQuery(ele).attr("id") === "mdx_sn_telegram"){
-                html_str += '<!-- telegram -->\n<a class="mdx-footer-icon-link" href="https://t.me/'+jQuery(ele).val()+'"><i class="mdx-sn-icon mdx_sn_telegram" mdui-tooltip="{content: \'@'+jQuery(ele).val()+'\', position: \'top\'}" title="'+jQuery(ele)[0].dataset.alt+'"> </i></a>\n';
-            }else if(jQuery(ele).attr("id") === "mdx_sn_steam"){
-                html_str += '<!-- steam -->\n<a class="mdx-footer-icon-link" href="https://steamcommunity.com/id/'+jQuery(ele).val()+'"><i class="mdx-sn-icon mdx_sn_steam" mdui-tooltip="{content: \''+jQuery(ele).val()+'\', position: \'top\'}" title="'+jQuery(ele)[0].dataset.alt+'"> </i></a>\n';
-            }else if(jQuery(ele).attr("id") === "mdx_sn_email"){
-                html_str += '<!-- email -->\n<a class="mdx-footer-icon-link" href="mailto:'+jQuery(ele).val()+'"><i class="mdx-sn-icon mdx_sn_email" mdui-tooltip="{content: \''+jQuery(ele).val()+'\', position: \'top\'}" title="'+jQuery(ele)[0].dataset.alt+'"> </i></a>\n';
-            }else{
-                html_str += '<!-- '+jQuery(ele).attr("id").split("_").pop()+' -->\n<a class="mdx-footer-icon-link" href="'+jQuery(ele).val()+'"><i class="mdx-sn-icon '+jQuery(ele).attr("id")+'" title="'+jQuery(ele)[0].dataset.alt+'"> </i></a>\n';
-            }
-        }
-    }
-    jQuery("#mdx_sn_result").text(html_str);
-}
-</script>
-</div><?php submit_button(); ?></form></div>

--- a/admin_style.php
+++ b/admin_style.php
@@ -90,7 +90,6 @@ wp_enqueue_script( 'wp-color-picker' );
 		} else {
 			mdx_update_option( 'mdx_post_def_img_url', esc_url_raw( $_POST['mdx_post_def_img_url'] ) );
 		}
-		mdx_update_option( 'mdx_buddha', sanitize_text_field( $_POST['mdx_buddha'] ) );
 		mdx_update_option( 'mdx_gravatar_actived', sanitize_text_field( $_POST['mdx_gravatar_actived'] ) );
 		mdx_update_option( 'mdx_link_rand_order', sanitize_text_field( $_POST['mdx_link_rand_order'] ) );
 		mdx_update_option( 'mdx_title_med', sanitize_text_field( $_POST['mdx_title_med'] ) );
@@ -299,19 +298,6 @@ wp_enqueue_script( 'wp-color-picker' );
                     <button type="button" id="insert-media-button-5" class="button" style="margin-top:5px;display:block"><?php _e( '选择图片', 'mdx' ); ?></button>
                     <p class="description"><?php _e( '指定文章默认特色图像，留空则使用主题内置默认特色图像。', 'mdx' ); ?></p>
                     <img id="img5" style="width:100%;max-width:300px;height:auto;margin-top:5px;"></img>
-                </td>
-            </tr>
-            <tr>
-                <th scope="row"><?php _e( '以正当方式保证代码健康', 'mdx' ); ?></th>
-                <td>
-					<?php $mdx_v_buddha = mdx_get_option( 'mdx_buddha' ); ?>
-                    <fieldset>
-                        <label><input type="radio" name="mdx_buddha" value="true" <?php if ( $mdx_v_buddha === 'true' ){ ?>checked="checked"<?php } ?>> <?php echo $trueon; ?>
-                        </label><br>
-                        <label><input type="radio" name="mdx_buddha" value="false" <?php if ( $mdx_v_buddha === 'false' ){ ?>checked="checked"<?php } ?>> <?php echo $falseoff; ?>
-                        </label><br>
-                        <p class="description"><?php _e( '有趣的小功能，开启后请自行查看页面HTML代码的页首部分', 'mdx' ); ?></p>
-                    </fieldset>
                 </td>
             </tr>
             </tbody>

--- a/admin_style.php
+++ b/admin_style.php
@@ -90,6 +90,7 @@ wp_enqueue_script( 'wp-color-picker' );
 		} else {
 			mdx_update_option( 'mdx_post_def_img_url', esc_url_raw( $_POST['mdx_post_def_img_url'] ) );
 		}
+		mdx_update_option( 'mdx_buddha', sanitize_text_field( $_POST['mdx_buddha'] ) );
 		mdx_update_option( 'mdx_gravatar_actived', sanitize_text_field( $_POST['mdx_gravatar_actived'] ) );
 		mdx_update_option( 'mdx_link_rand_order', sanitize_text_field( $_POST['mdx_link_rand_order'] ) );
 		mdx_update_option( 'mdx_title_med', sanitize_text_field( $_POST['mdx_title_med'] ) );
@@ -298,6 +299,19 @@ wp_enqueue_script( 'wp-color-picker' );
                     <button type="button" id="insert-media-button-5" class="button" style="margin-top:5px;display:block"><?php _e( '选择图片', 'mdx' ); ?></button>
                     <p class="description"><?php _e( '指定文章默认特色图像，留空则使用主题内置默认特色图像。', 'mdx' ); ?></p>
                     <img id="img5" style="width:100%;max-width:300px;height:auto;margin-top:5px;"></img>
+                </td>
+            </tr>
+            <tr>
+                <th scope="row"><?php _e( '以正当方式保证代码健康', 'mdx' ); ?></th>
+                <td>
+					<?php $mdx_v_buddha = mdx_get_option( 'mdx_buddha' ); ?>
+                    <fieldset>
+                        <label><input type="radio" name="mdx_buddha" value="true" <?php if ( $mdx_v_buddha === 'true' ){ ?>checked="checked"<?php } ?>> <?php echo $trueon; ?>
+                        </label><br>
+                        <label><input type="radio" name="mdx_buddha" value="false" <?php if ( $mdx_v_buddha === 'false' ){ ?>checked="checked"<?php } ?>> <?php echo $falseoff; ?>
+                        </label><br>
+                        <p class="description"><?php _e( '有趣的小功能，开启后请自行查看页面HTML代码的页首部分', 'mdx' ); ?></p>
+                    </fieldset>
                 </td>
             </tr>
             </tbody>

--- a/header.php
+++ b/header.php
@@ -37,15 +37,15 @@ if ( ! $isUsedYoastSEO ) {
 }
 
 /* 获取当前页面图 */
-if ( ( is_single() || is_page() ) && ! empty( wp_get_attachment_image_src( get_post_thumbnail_id( $post->ID ), 'full' )[0] ) ) {
+if ( (is_single() || is_page()) && ! empty( wp_get_attachment_image_src( get_post_thumbnail_id( $post->ID ), 'full' )[0] ) ) {
 	$index_image = wp_get_attachment_image_src( get_post_thumbnail_id( $post->ID ), 'full' )[0];
-} else if ( ! empty( mdx_get_option( 'mdx_share_image' ) ) ) {
-	$index_image = mdx_get_option( 'mdx_share_image' );
-} else if ( strncmp( mdx_get_option( 'mdx_index_img' ), "--BingImages", 12 ) !== 0 ) {
+} else if (!empty(mdx_get_option('mdx_share_image'))) {
+    $index_image = mdx_get_option( 'mdx_share_image' );
+} else if(strncmp(mdx_get_option( 'mdx_index_img' ), "--BingImages", 12) !== 0) {
 	$index_image = mdx_get_option( 'mdx_index_img' );
 } else {
 	$twitter_card_type = "summary";
-	$index_image       = get_site_icon_url();
+    $index_image = get_site_icon_url();
 }
 
 /* 获取当前页面社会描述 */
@@ -63,42 +63,7 @@ if ( is_single() || is_page() ) {
 }
 
 $mdx_current_url = mdx_get_now_url( is_single(), isset( $post ) ? $post->ID : 0 );
-?>
-<?php if ( mdx_get_option( "mdx_buddha" ) === "true" ): ?>
-    <!--
-							_ooOoo_
-						   o8888888o
-						   88" . "88
-						   (| -_- |)
-							O\ = /O
-						____/`---'\____
-					  .   ' \\| |// `.
-					   / \\||| : |||// \
-					 / _||||| -:- |||||- \
-					   | | \\\ - /// | |
-					 | \_| ''\---/'' | |
-					  \ .-\__ `-` ___/-. /
-				   ___`. .' /--.--\ `. . __
-				."" '< `.___\_<|>_/___.' >'"".
-			   | | : `- \`.;`\ _ /`;.`/ - ` : | |
-				 \ \ `-. \_ __\ /__ _/ .-` / /
-		 ======`-.____`-.___\_____/___.-`____.-'======
-							`=---='
-
-		 .............................................
-				  佛祖保佑             永无BUG
-
-				  写字楼里写字间，写字间里程序员。
-				  程序人员写程序，又拿程序换酒钱。
-				  酒醒只在网上坐，酒醉还来网下眠。
-				  酒醉酒醒日复日，网上网下年复年。
-				  但愿老死电脑间，不愿鞠躬老板前。
-				  奔驰宝马贵者趣，公交自行程序员。
-				  别人笑我忒疯癫，我笑自己命太贱。
-				  不见满街漂亮妹，哪个归得程序员？
-	-->
-<?php endif; // 博学多才的Axton一定会重写这个诗吧？ ?>
-<!DOCTYPE html>
+?><!DOCTYPE html>
 <html <?php language_attributes(); ?>>
 <head>
     <!-- The <Head> part of the theme starts to load -->

--- a/header.php
+++ b/header.php
@@ -3,127 +3,135 @@
 global $wp;
 global $files_root;
 global $page, $paged;
-$opt_mdx_share_twitter_card = mdx_get_option("mdx_share_twitter_card");
+$opt_mdx_share_twitter_card = mdx_get_option( "mdx_share_twitter_card" );
 
 // 获取当前页面Title
-$title = "";
-$title .= wp_title('-', false, 'right');
-$title .= get_bloginfo('name');
-$site_description = get_bloginfo('description', 'display');
-if ($site_description && (is_home() || is_front_page())) $title .= " - $site_description";
-if ($paged >= 2 || $page >= 2) $title .= ' - ' . sprintf(__('第 %s 页'), max($paged, $page));
+$title = wp_title( '-', false, 'right' );
 
-// 获取当前页面分享图
-$opt_mdx_index_img = mdx_get_option('mdx_index_img');
-$coverPicIsBing = (bool)substr($opt_mdx_index_img, 0, 6) == "--Bing";
-$index_image = !(!(is_single() || is_page()) && $coverPicIsBing)?((is_single() || is_page())?(wp_get_attachment_image_src(get_post_thumbnail_id($post->ID), 'full')[0]??""):$opt_mdx_index_img):mdx_get_option('mdx_side_head');
-
-// 获取当前页面社会分享描述
-$social_describe = "";
-$mdx_des = mdx_get_option('mdx_seo_des');
-if (is_single() || is_page()) {
-    if (post_password_required()) {
-        $social_describe = translate('这篇文章受密码保护，输入密码后才能查看。', 'mdx');
-    } else {
-        $social_describe = mdx_get_post_excerpt($post, 100);
-    }
-} else if ($mdx_des != '') {
-    $social_describe = $mdx_des;
-} else {
-    $social_describe = get_bloginfo('description', 'display');
+// Yoast SEO 接管配置
+/** @var bool 是否使用YoastSEO */
+$isUsedYoastSEO = defined( "WPSEO_NAMESPACES" );
+if ( ! $isUsedYoastSEO ) {
+	$title            .= get_bloginfo( 'name' );
+	$site_description = get_bloginfo( 'description', 'display' );
+	if ( ! empty( $site_description ) && ( is_home() || is_front_page() ) ) {
+		$title .= " - $site_description";
+	}
+	if ( $paged >= 2 || $page >= 2 ) {
+		$title .= ' - ' . sprintf( __( '第 %s 页' ), max( $paged, $page ) );
+	}
 }
+
+/* 获取当前页面图 */
+$opt_mdx_index_img = mdx_get_option( 'mdx_index_img' );
+$coverPicIsBing = (bool) substr( $opt_mdx_index_img, 0, 6 ) == "--Bing";
+$index_image = ! ( ! ( is_single() || is_page() ) && $coverPicIsBing ) ? ( ( is_single() || is_page() ) ? ( wp_get_attachment_image_src( get_post_thumbnail_id( $post->ID ), 'full' )[0] ?? "" ) : $opt_mdx_index_img ) : mdx_get_option( 'mdx_side_head' );
+
+/* 获取当前页面社会描述 */
+$mdx_des = mdx_get_option( 'mdx_seo_des' );
+if ( is_single() || is_page() ) {
+	if ( post_password_required() ) {
+		$page_describe = translate( '这篇文章受密码保护，输入密码后才能查看。', 'mdx' );
+	} else {
+		$page_describe = mdx_get_post_excerpt( $post, 100 );
+	}
+} else if ( $mdx_des != '' ) {
+	$page_describe = $mdx_des;
+} else {
+	$page_describe = get_bloginfo( 'description', 'display' );
+}
+
+$mdx_current_url = mdx_get_now_url( is_single(), isset( $post ) ? $post->ID : 0 );
 ?><!DOCTYPE html>
 <html <?php language_attributes(); ?>>
 <head>
-    <meta charset="<?php bloginfo('charset'); ?>">
-    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=<?php echo (mdx_get_option('mdx_allow_scale') == 'false')?"1, user-scalable=no":"5"; ?>">
-    <?php if (mdx_get_option('mdx_speed_pre') == 'true' && !is_404()) {
-        if (is_home()) { $mdx_js_name2 = 'js'; } else if (is_category() || is_archive() || is_search()) { $mdx_js_name2 = 'ac'; } else if (is_single()) { $mdx_js_name2 = 'post'; } else if (is_page()) { $mdx_js_name2 = 'page'; } else { $mdx_js_name2 = 'js'; } ?>
-        <link rel="preload" href="<?php echo $files_root; ?>/js/common.js?ver=<?php echo get_option("mdx_version_commit"); ?>" as="script">
-        <link rel="preload" href="<?php echo $files_root; ?>/js/<?php echo $mdx_js_name2 ?>.js?ver=<?php echo get_option("mdx_version_commit"); ?>" as="script">
-        <link rel="preload" href="<?php echo $files_root; ?>/mdui/icons/material-icons/<?php echo (mdx_get_option("mdx_md2") == "false")?"MaterialIcons-Regular.woff2":"material_2_icon_font.woff2" ?>" as="font" type="font/woff2" crossorigin>
-        <?php if (mdx_get_option('mdx_md2') == "true" && mdx_get_option('mdx_md2_font') == "true") { ?>
+    <!-- The <Head> part of the theme starts to load -->
+    <meta charset="<?php bloginfo( 'charset' ); ?>">
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=<?php echo ( mdx_get_option( 'mdx_allow_scale' ) == 'false' ) ? "1, user-scalable=no" : "5"; ?>">
+	<?php if ( mdx_get_option( 'mdx_speed_pre' ) == 'true' && ! is_404() ) {
+		if ( is_home() ) {
+			$mdx_js_name2 = 'js';
+		} else if ( is_category() || is_archive() || is_search() ) {
+			$mdx_js_name2 = 'ac';
+		} else if ( is_single() ) {
+			$mdx_js_name2 = 'post';
+		} else if ( is_page() ) {
+			$mdx_js_name2 = 'page';
+		} else {
+			$mdx_js_name2 = 'js';
+		} ?>
+        <link rel="preload" href="<?php echo $files_root; ?>/js/common.js?ver=<?php echo get_option( "mdx_version_commit" ); ?>" as="script">
+        <link rel="preload" href="<?php echo $files_root; ?>/js/<?php echo $mdx_js_name2 ?>.js?ver=<?php echo get_option( "mdx_version_commit" ); ?>" as="script">
+        <link rel="preload" href="<?php echo $files_root; ?>/mdui/icons/material-icons/<?php echo ( mdx_get_option( "mdx_md2" ) == "false" ) ? "MaterialIcons-Regular.woff2" : "material_2_icon_font.woff2" ?>" as="font" type="font/woff2" crossorigin>
+		<?php if ( mdx_get_option( 'mdx_md2' ) == "true" && mdx_get_option( 'mdx_md2_font' ) == "true" ) { ?>
             <link rel="preload" href="<?php echo $files_root; ?>/fonts/Montserrat-Regular.woff2" as="font" type="font/woff2" crossorigin>
             <link rel="preload" href="<?php echo $files_root; ?>/fonts/Montserrat-SemiBold.woff2" as="font" type="font/woff2" crossorigin>
-        <?php }} ?>
+		<?php }
+	} ?>
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <?php if (mdx_get_option('mdx_safari') == "true") { ?>
-        <link rel="mask-icon" href="<?php echo mdx_get_option('mdx_svg'); ?>" color="<?php echo mdx_get_option('mdx_svg_color'); ?>">
-    <?php } if (mdx_get_option("mdx_title_med") == "diy") { ?>
+	<?php if ( mdx_get_option( 'mdx_safari' ) == "true" ) { ?>
+        <link rel="mask-icon" href="<?php echo mdx_get_option( 'mdx_svg' ); ?>" color="<?php echo mdx_get_option( 'mdx_svg_color' ); ?>">
+	<?php }
+	if ( mdx_get_option( "mdx_title_med" ) == "diy" ) { ?>
         <title itemprop="name"><?php echo $title; ?></title>
-    <?php } if (is_single() || is_page()) {
-        if (function_exists('get_query_var')) {
-            $cpage = intval(get_query_var('cpage'));
-            $commentPage = intval(get_query_var('comment-page'));
-        }
-        if (!empty($cpage) || !empty($commentPage)) {
-            echo '<meta name="robots" content="noindex, nofollow">';
-        }
-    } if (!is_404()) { ?>
-        <meta property="og:title" content="<?php echo $title; ?>">
-        <meta property="og:type" content="article">
-        <meta property="og:url" content="<?php
-        $mdx_current_url = mdx_get_now_url(is_single(), isset($post) ? (int)$post->ID : 0);
-        echo $mdx_current_url; ?>">
-        <?php
-        $mdx_des = mdx_get_option('mdx_seo_des');
-        $mdx_s_key = mdx_get_option('mdx_seo_key');
-        $mdx_a_des = mdx_get_option('mdx_auto_des');
-        $opt_mdx_share_twitter_username = mdx_get_option('mdx_share_twitter_username');?>
-        <meta property="og:description" content="<?php echo $social_describe; ?>">
-        <meta property="og:image" content="<?php echo $index_image; ?>">
-        <meta name="twitter:card" content="<?php echo (is_single()||is_page())?(($opt_mdx_share_twitter_card=="summary"||$opt_mdx_share_twitter_card=="summary_large_image")?$opt_mdx_share_twitter_card:"summary"):"summary"; ?>">
-        <?php if(preg_match("/@?([A-Za-z0-9_]+)/i",$opt_mdx_share_twitter_username,$v_opt_mdx_share_twitter_username)>0){ ?>
-            <meta name="twitter:site" content="@<?php echo $v_opt_mdx_share_twitter_username[1]; ?>">
-        <?php } ?>
-        <meta name="twitter:title" content="<?php echo $title; ?>">
-        <meta name="twitter:description" content="<?php echo $social_describe; ?>">
-        <meta name="twitter:url" content="<?php echo $mdx_current_url; ?>">
-        <meta name="twitter:image" content="<?php echo $index_image; ?>">
+	<?php }
+	if ( is_single() || is_page() ) {
+		if ( function_exists( 'get_query_var' ) ) {
+			$cpage       = intval( get_query_var( 'cpage' ) );
+			$commentPage = intval( get_query_var( 'comment-page' ) );
+		}
+		if ( ! empty( $cpage ) || ! empty( $commentPage ) ) {
+			echo '<meta name="robots" content="noindex, nofollow">';
+		}
+	}
+	if ( ! is_404() ) { ?>
+		<?php
+		$mdx_des   = mdx_get_option( 'mdx_seo_des' );
+		$mdx_s_key = mdx_get_option( 'mdx_seo_key' );
+		$mdx_a_des = mdx_get_option( 'mdx_auto_des' );
+		?>
+
+		<?php if ( ! $isUsedYoastSEO ): ?>
+            <meta property="og:title" content="<?php echo $title; ?>">
+            <meta property="og:type" content="article">
+            <meta property="og:url" content="<?php echo $mdx_current_url; ?>">
+			<?php $opt_mdx_share_twitter_username = mdx_get_option( 'mdx_share_twitter_username' ); ?>
+            <meta property="og:description" content="<?php echo $page_describe; ?>">
+            <meta property="og:image" content="<?php echo $index_image; ?>">
+            <meta name="twitter:card" content="<?php echo ( is_single() || is_page() ) ? ( ( $opt_mdx_share_twitter_card == "summary" || $opt_mdx_share_twitter_card == "summary_large_image" ) ? $opt_mdx_share_twitter_card : "summary" ) : "summary"; ?>">
+			<?php if ( ! empty( $opt_mdx_share_twitter_username ) ) { ?>
+                <meta name="twitter:site" content="@<?php echo ltrim( $opt_mdx_share_twitter_username, "@" ); ?>"><?php } ?>
+		<?php endif; ?>
+
         <meta itemprop="name" content="<?php echo $title; ?>">
         <meta itemprop="image" content="<?php echo $index_image; ?>">
-        <?php
-        if ($mdx_des !== '') {
-            if ($mdx_a_des === 'true') {
-                if (is_single() || is_page()) {
-                    ?>
-                    <meta name="description" itemprop="description" content="<?php if (post_password_required()) {
-                        _e('这篇文章受密码保护，输入密码后才能查看。', 'mdx');
-                    } else {
-                        echo mdx_get_post_excerpt($post, 100);
-                    } ?>">
-                <?php } else {
-                    ?>
-                    <meta name="description" itemprop="description" content="<?php echo $mdx_des; ?>">
-                <?php }
-            } else {
-                ?>
-                <meta name="description" itemprop="description" content="<?php echo $mdx_des; ?>">
-            <?php }
-        }
-        if ($mdx_s_key != '') {
-            ?>
-            <meta name="keywords" content="<?php bloginfo('name');
-            echo ',' . $mdx_s_key; ?>">
-        <?php }
-    }
-    if (mdx_get_option('mdx_chrome_color') == 'true') {
-        $mdx_theme_color = mdx_get_option('mdx_styles_hex');
-        if (mdx_get_option('mdx_styles') === "white") {
-            $mdx_theme_color = "#ffffff";
-        }
-        if (is_single()) {
-            $mdx_theme_color_page = get_post_meta($post->ID, "mdx_styles_hex", true);
-            if ($mdx_theme_color_page != 'def' && $mdx_theme_color_page != '') {
-                $mdx_theme_color = $mdx_theme_color_page;
-            }
-            if (get_post_meta($post->ID, "mdx_styles", true) === "white") {
-                $mdx_theme_color = "#ffffff";
-            }
-        } ?>
+        <meta name="description" itemprop="description" content="<?php echo $page_describe; ?>">
+		<?php
+		if ( $mdx_s_key != '' ) {
+			?>
+            <meta name="keywords" content="<?php bloginfo( 'name' );
+			echo ',' . $mdx_s_key; ?>">
+		<?php }
+	}
+	if ( mdx_get_option( 'mdx_chrome_color' ) == 'true' ) {
+		$mdx_theme_color = mdx_get_option( 'mdx_styles_hex' );
+		if ( mdx_get_option( 'mdx_styles' ) === "white" ) {
+			$mdx_theme_color = "#ffffff";
+		}
+		if ( is_single() ) {
+			$mdx_theme_color_page = get_post_meta( $post->ID, "mdx_styles_hex", true );
+			if ( $mdx_theme_color_page != 'def' && $mdx_theme_color_page != '' ) {
+				$mdx_theme_color = $mdx_theme_color_page;
+			}
+			if ( get_post_meta( $post->ID, "mdx_styles", true ) === "white" ) {
+				$mdx_theme_color = "#ffffff";
+			}
+		} ?>
         <meta name="theme-color" content="<?php echo $mdx_theme_color; ?>">
         <meta name="mdx-main-color" content="<?php echo $mdx_theme_color; ?>">
-    <?php } ?>
-    <link rel="pingback" href="<?php bloginfo('pingback_url'); ?>">
-    <?php wp_head(); echo htmlspecialchars_decode(mdx_get_option('mdx_head_js')); ?>
+	<?php } ?>
+    <link rel="pingback" href="<?php bloginfo( 'pingback_url' ); ?>">
+    <!-- The <head> part of the theme is loaded -->
+	<?php wp_head();
+	echo htmlspecialchars_decode( mdx_get_option( 'mdx_head_js' ) ); ?>
 </head>

--- a/header.php
+++ b/header.php
@@ -20,14 +20,32 @@ if ( ! $isUsedYoastSEO ) {
 	if ( $paged >= 2 || $page >= 2 ) {
 		$title .= ' - ' . sprintf( __( '第 %s 页' ), max( $paged, $page ) );
 	}
+
+	if ( ( is_single() || is_page() ) && ! empty( wp_get_attachment_image_src( get_post_thumbnail_id( $post->ID ), 'full' )[0] ) ) {
+		if ( ( $opt_mdx_share_twitter_card == "summary" || $opt_mdx_share_twitter_card == "summary_large_image" ) ) {
+			$twitter_card_type = ( $opt_mdx_share_twitter_card );
+		} else {
+			$twitter_card_type = ( "summary" );
+		}
+	} else {
+		if ( empty( mdx_get_option( 'mdx_share_image' ) ) ) {
+			$twitter_card_type = "summary";
+		} else {
+			$twitter_card_type = "summary_large_image";
+		}
+	}
 }
 
 /* 获取当前页面图 */
-$opt_mdx_index_img = mdx_get_option( 'mdx_index_img' );
-if ( ! ( ! ( is_single() || is_page() ) && substr( $opt_mdx_index_img, 0, 6 ) == "--Bing" ) ) {
-	$index_image = is_single() || is_page() ? ( wp_get_attachment_image_src( get_post_thumbnail_id( $post->ID ), 'full' )[0] ?? "" ) : $opt_mdx_index_img;
+if ( (is_single() || is_page()) && ! empty( wp_get_attachment_image_src( get_post_thumbnail_id( $post->ID ), 'full' )[0] ) ) {
+	$index_image = wp_get_attachment_image_src( get_post_thumbnail_id( $post->ID ), 'full' )[0];
+} else if (!empty(mdx_get_option('mdx_share_image'))) {
+    $index_image = mdx_get_option( 'mdx_share_image' );
+} else if(strncmp(mdx_get_option( 'mdx_index_img' ), "--BingImages", 12) !== 0) {
+	$index_image = mdx_get_option( 'mdx_index_img' );
 } else {
-	$index_image = mdx_get_option( 'mdx_side_head' );
+	$twitter_card_type = "summary";
+    $index_image = get_site_icon_url();
 }
 
 /* 获取当前页面社会描述 */
@@ -101,7 +119,7 @@ $mdx_current_url = mdx_get_now_url( is_single(), isset( $post ) ? $post->ID : 0 
 			<?php $opt_mdx_share_twitter_username = mdx_get_option( 'mdx_share_twitter_username' ); ?>
             <meta property="og:description" content="<?php echo $page_describe; ?>">
             <meta property="og:image" content="<?php echo $index_image; ?>">
-            <meta name="twitter:card" content="<?php echo ( is_single() || is_page() ) ? ( ( $opt_mdx_share_twitter_card == "summary" || $opt_mdx_share_twitter_card == "summary_large_image" ) ? $opt_mdx_share_twitter_card : "summary" ) : "summary"; ?>">
+            <meta name="twitter:card" content="<?php echo $twitter_card_type; ?>">
 			<?php if ( ! empty( $opt_mdx_share_twitter_username ) ) { ?>
                 <meta name="twitter:site" content="@<?php echo ltrim( $opt_mdx_share_twitter_username, "@" ); ?>"><?php } ?>
 		<?php endif; ?>

--- a/header.php
+++ b/header.php
@@ -24,8 +24,11 @@ if ( ! $isUsedYoastSEO ) {
 
 /* 获取当前页面图 */
 $opt_mdx_index_img = mdx_get_option( 'mdx_index_img' );
-$coverPicIsBing = (bool) substr( $opt_mdx_index_img, 0, 6 ) == "--Bing";
-$index_image = ! ( ! ( is_single() || is_page() ) && $coverPicIsBing ) ? ( ( is_single() || is_page() ) ? ( wp_get_attachment_image_src( get_post_thumbnail_id( $post->ID ), 'full' )[0] ?? "" ) : $opt_mdx_index_img ) : mdx_get_option( 'mdx_side_head' );
+if ( ! ( ! ( is_single() || is_page() ) && substr( $opt_mdx_index_img, 0, 6 ) == "--Bing" ) ) {
+	$index_image = is_single() || is_page() ? ( wp_get_attachment_image_src( get_post_thumbnail_id( $post->ID ), 'full' )[0] ?? "" ) : $opt_mdx_index_img;
+} else {
+	$index_image = mdx_get_option( 'mdx_side_head' );
+}
 
 /* 获取当前页面社会描述 */
 $mdx_des = mdx_get_option( 'mdx_seo_des' );

--- a/header.php
+++ b/header.php
@@ -37,15 +37,15 @@ if ( ! $isUsedYoastSEO ) {
 }
 
 /* 获取当前页面图 */
-if ( (is_single() || is_page()) && ! empty( wp_get_attachment_image_src( get_post_thumbnail_id( $post->ID ), 'full' )[0] ) ) {
+if ( ( is_single() || is_page() ) && ! empty( wp_get_attachment_image_src( get_post_thumbnail_id( $post->ID ), 'full' )[0] ) ) {
 	$index_image = wp_get_attachment_image_src( get_post_thumbnail_id( $post->ID ), 'full' )[0];
-} else if (!empty(mdx_get_option('mdx_share_image'))) {
-    $index_image = mdx_get_option( 'mdx_share_image' );
-} else if(strncmp(mdx_get_option( 'mdx_index_img' ), "--BingImages", 12) !== 0) {
+} else if ( ! empty( mdx_get_option( 'mdx_share_image' ) ) ) {
+	$index_image = mdx_get_option( 'mdx_share_image' );
+} else if ( strncmp( mdx_get_option( 'mdx_index_img' ), "--BingImages", 12 ) !== 0 ) {
 	$index_image = mdx_get_option( 'mdx_index_img' );
 } else {
 	$twitter_card_type = "summary";
-    $index_image = get_site_icon_url();
+	$index_image       = get_site_icon_url();
 }
 
 /* 获取当前页面社会描述 */
@@ -63,7 +63,42 @@ if ( is_single() || is_page() ) {
 }
 
 $mdx_current_url = mdx_get_now_url( is_single(), isset( $post ) ? $post->ID : 0 );
-?><!DOCTYPE html>
+?>
+<?php if ( mdx_get_option( "mdx_buddha" ) === "true" ): ?>
+    <!--
+							_ooOoo_
+						   o8888888o
+						   88" . "88
+						   (| -_- |)
+							O\ = /O
+						____/`---'\____
+					  .   ' \\| |// `.
+					   / \\||| : |||// \
+					 / _||||| -:- |||||- \
+					   | | \\\ - /// | |
+					 | \_| ''\---/'' | |
+					  \ .-\__ `-` ___/-. /
+				   ___`. .' /--.--\ `. . __
+				."" '< `.___\_<|>_/___.' >'"".
+			   | | : `- \`.;`\ _ /`;.`/ - ` : | |
+				 \ \ `-. \_ __\ /__ _/ .-` / /
+		 ======`-.____`-.___\_____/___.-`____.-'======
+							`=---='
+
+		 .............................................
+				  佛祖保佑             永无BUG
+
+				  写字楼里写字间，写字间里程序员。
+				  程序人员写程序，又拿程序换酒钱。
+				  酒醒只在网上坐，酒醉还来网下眠。
+				  酒醉酒醒日复日，网上网下年复年。
+				  但愿老死电脑间，不愿鞠躬老板前。
+				  奔驰宝马贵者趣，公交自行程序员。
+				  别人笑我忒疯癫，我笑自己命太贱。
+				  不见满街漂亮妹，哪个归得程序员？
+	-->
+<?php endif; // 博学多才的Axton一定会重写这个诗吧？ ?>
+<!DOCTYPE html>
 <html <?php language_attributes(); ?>>
 <head>
     <!-- The <Head> part of the theme starts to load -->

--- a/includes/default_value.php
+++ b/includes/default_value.php
@@ -69,6 +69,7 @@ $mdx_default_values = array(
     'mdx_styles_dark' => 'disable',
     'mdx_md2' => 'false',
     'mdx_md2_font' => 'false',
+	'mdx_buddha' => 'false',
     'mdx_login_md' => 'false',
     'mdx_chrome_color' => 'true',
     'mdx_title_bar' => 'false',

--- a/includes/default_value.php
+++ b/includes/default_value.php
@@ -69,7 +69,6 @@ $mdx_default_values = array(
     'mdx_styles_dark' => 'disable',
     'mdx_md2' => 'false',
     'mdx_md2_font' => 'false',
-	'mdx_buddha' => 'false',
     'mdx_login_md' => 'false',
     'mdx_chrome_color' => 'true',
     'mdx_title_bar' => 'false',

--- a/includes/default_value.php
+++ b/includes/default_value.php
@@ -34,6 +34,7 @@ $mdx_default_values = array(
     'mdx_share_area' => 'all',
     'mdx_share_twitter_card' => 'summary',
     'mdx_share_twitter_username' => '',
+	'mdx_share_image' => '',
     'mdx_hot_posts' => 'false',
     'mdx_hot_posts_get' => 'cat',
     'mdx_hot_posts_num' => '10',


### PR DESCRIPTION
## About

**The main modification content is the social sharing module.**

Optimize my last Pull Request #196 .

- Added support for Yoast SEO plugin (because this one is too famous).
- - When Yoast SEO is enabled, it will stop outputting social sharing codes to allow Yoast SEO to take over.
- - When Yoast SEO is enabled, a single `<title>` will be output so that Yoast SEO title rewriting can be used normally.
- Added the option to customize the default picture of the social sharing options.
- Optimized the setting of Twitter username, will use the `ltrim()`.

Need @yrccondor  to add the function of picture display to the following code:
https://github.com/AH-dark/mdx/blob/c69f7ba14a6df40e309e16ec544d2bdeea742720/admin_fn.php#L292-L293
Sorry I don’t know how to set the display picture. o(╥﹏╥)o

### About how the default social sharing pictures are presented:
[![1DDT.png](https://q2.a1pic.cn/1DDT.png)](https://www.alphapic.org.cn/p/1DDT)
