### PR TITLE
Fixed border-radius at iOS Safari

### DIFF
--- a/css/md2.css
+++ b/css/md2.css
@@ -39,6 +39,8 @@
     font-display: swap;
 }
 .mdui-dialog, .mdui-menu, .mdui-card, article div.mdui-panel.mdui-panel-gapless, .mdui-table-fluid, .mdx-author-c, .mdx-hot-posts, .mdx-same-posts, .mdui-img-rounded, .links-c, .links-co > a, .outOfSearch, .mdx-first-simple .mdx-hot-posts, .searchCard, .mdx-github-cot, .mdui-typo pre, #mdx-cookie-notice, article.indexgaid, #login_error, main .mdx-postlist-simple.mdx-postlist-simple-sta {
+    transform: rotate(0deg);
+    -webkit-transform: rotate(0deg);
     border-radius: 8px!important;
 }
 .mdx-first-simple .mdx-postlist-simple.mdx-postlist-simple-has-no-img {


### PR DESCRIPTION
在iOS的Safari上，推荐文章的圆角不能正常显示，需要配合transform属性使用。下图左边加入了transform属性，右边是原先的效果。
![a5c6034b1843ebdbff6283519ea58293](https://user-images.githubusercontent.com/36611837/211129632-3d6ab68a-08c0-426c-8592-f48c0dfba650.jpg)
